### PR TITLE
Font awesome docutils transformer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Current
 - Update to new django versions (2.2 and 2.3)
 - Remove unsupported django versions (1.8, 1.9, 1.10, 2.0, 2.1)
 - Cleanup CI, add caching
+- Add ``InjectFontAwesome`` transformer to inject icon ``<em>`` tags for
+  font awesome based on regex patterns
 
 0.4.0 <2017-02-21>
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,38 @@ view:
 
 .. code-block:: python
 
+    BASED_LIB_RST = {  # Optional, automatically maps roles, directives and transformers
+        'docutils': {
+            'raw_enabled': True,
+            'strip_comments': True,
+            'initial_header_level': 2,
+        },
+        'roles': {
+            'local': {
+                'gh': 'django_docutils.lib.roles.github.github_role',
+                'twitter': 'django_docutils.lib.roles.twitter.twitter_role',
+                'email': 'django_docutils.lib.roles.email.email_role',
+            }
+        },
+        'font_awesome': {  # Transformer to inject <em class="<class>"></em>
+            'url_patterns': {
+                r'.*github.com.*': 'fab fa-github',
+                r'.*twitter.com.*': 'fab fa-twitter',
+                r'.*amzn.to.*': 'fab fa-amazon',
+                r'.*amazon.com.*': 'fab fa-amazon',
+                r'.*news.ycombinator.com*': 'fab fa-hacker-news',
+                r'.*leanpub.com.*': 'fab fa-leanpub',
+                r'.*python.org.*': 'fab fa-python',
+                r'.*pypi.org.*': 'fab fa-python',
+                r'.*djangoproject.com.*': 'fab fa-python',
+                r'.*wikipedia.org.*': 'fab fa-wikipedia',
+                r'((rtfd|readthedocs).)*$': 'fab fa-books',
+                r'^mailto:.*': 'fas fa-envelope',
+                r'((?!mywebsite.com|localhost).)*$': 'fas fa-external-link',
+            }
+        },
+    }
+
     BASED_LIB_TEXT = {  # Optional
         'uncapitalized_word_filters': ['project.my_module.my_capitalization_fn']
     }

--- a/django_docutils/lib/publisher.py
+++ b/django_docutils/lib/publisher.py
@@ -1,17 +1,11 @@
 from django.utils.encoding import force_bytes, force_text
 from django.utils.safestring import mark_safe
-
 from docutils import io, nodes, readers
-from docutils.core import (
-    Publisher,
-    publish_doctree as docutils_publish_doctree,
-)
-
-from django_docutils.lib.transforms.ads import InjectAds
+from docutils.core import Publisher, publish_doctree as docutils_publish_doctree
 
 from .directives import register_based_directives
 from .roles import register_based_roles
-from .settings import BASED_LIB_RST
+from .settings import BASED_LIB_RST, INJECT_FONT_AWESOME
 from .transforms.toc import Contents
 from .writers import BasedWriter
 
@@ -155,7 +149,13 @@ def publish_html_from_doctree(
     writer = BasedWriter()
 
     if inject_ads:
+        from django_docutils.lib.transforms.ads import InjectAds
         doctree.transformer.add_transform(InjectAds.keywords(ad_keywords))
+
+    if INJECT_FONT_AWESOME:
+        from django_docutils.lib.transforms.font_awesome import InjectFontAwesome
+        doctree.transformer.add_transform(InjectFontAwesome)
+
     doctree.transformer.apply_transforms()
 
     if toc_only:  # special flag to only return toc, used for sidebars

--- a/django_docutils/lib/settings.py
+++ b/django_docutils/lib/settings.py
@@ -1,13 +1,7 @@
 from django.conf import settings
 
-BASED_LIB_RST = getattr(
-    settings,
-    'BASED_LIB_RST',
-    {
-        "font_awesome": {
-            "url_patterns": {
-                r'.*twitter.com.*': 'fab fa-twitter',
-            }
-        }
-    },
+BASED_LIB_RST = getattr(settings, 'BASED_LIB_RST', {})
+
+INJECT_FONT_AWESOME = (
+    BASED_LIB_RST.get('font_awesome', {}).get('url_patterns') is not None
 )

--- a/django_docutils/lib/settings.py
+++ b/django_docutils/lib/settings.py
@@ -1,3 +1,13 @@
 from django.conf import settings
 
-BASED_LIB_RST = getattr(settings, 'BASED_LIB_RST', {})
+BASED_LIB_RST = getattr(
+    settings,
+    'BASED_LIB_RST',
+    {
+        "font_awesome": {
+            "url_patterns": {
+                r'.*twitter.com.*': 'fab fa-twitter',
+            }
+        }
+    },
+)

--- a/django_docutils/lib/transforms/font_awesome.py
+++ b/django_docutils/lib/transforms/font_awesome.py
@@ -1,0 +1,29 @@
+import re
+
+from docutils import nodes, utils
+from docutils.transforms import Transform
+
+from django_docutils.lib.settings import BASED_LIB_RST
+
+url_patterns = BASED_LIB_RST.get('font_awesome', {}).get('url_patterns', {})
+
+class InjectFontAwesome(Transform):
+
+    default_priority = 680
+
+    def apply(self):
+        for target in self.document.traverse(nodes.reference):
+            if target.hasattr('refuri'):
+                url = target['refuri']
+                print(url_patterns)
+                for url_pattern, classes in url_patterns.items():
+                    if re.match(url_pattern, url):
+
+                        fa_tag = f'<em class="{classes}"></em>'
+                        title = utils.unescape(target[0])
+                        print(target, url, fa_tag,title)
+                        rn = nodes.reference('', '', internal=True, refuri=url)
+                        rn += nodes.raw('', fa_tag, format='html')
+                        rn += nodes.Text(title, title)
+                        target.replace_self(rn)
+                        break


### PR DESCRIPTION
Removing more tech debt on devel.tech and hskflashcards.com

Font awesome was formerly applied via a scss track where the codepoint was added. This doesn't work with font awesome svg replacement and in general isn't very portable

Create a transformer to inject `<em class="fas fa-{icon}"/>` based on a settings config