### PR TITLE
docs: Move to sphinx-autoissues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
 - _Add your latest changes from PRs here_
 
+### Documentation
+
+- Move CHANGES to sphinx-autoissues, #350
+
 ## django-docutils 0.7.0 (2022-08-16)
 
 ### Development
@@ -14,21 +18,21 @@ Infrastructure updates for static type checking and doctest examples.
 - Add .tool-versions, .python-version
 - Run code through black w/o `--skip-string-normalization`
 
-- Initial [doctests] support added, via #342 
+- Initial [doctests] support added, via #342
 
   [doctests]: https://docs.python.org/3/library/doctest.html
 
-- Initial [mypy] validation, via #342 
+- Initial [mypy] validation, via #342
 
   [mypy]: https://github.com/python/mypy
 
-- CI (tests, docs): Improve caching of python dependencies via
-  `action/setup-python`'s v3/4's new poetry caching, via #342
+- CI (tests, docs): Improve caching of python dependencies via `action/setup-python`'s v3/4's new
+  poetry caching, via #342
 
 - CI (docs): Skip if no `PUBLISH` condition triggered, via #342
 
-- CI: Remove `.pre-commit-config.yaml`, users should know enough to handle these
-  things themselves, via #342
+- CI: Remove `.pre-commit-config.yaml`, users should know enough to handle these things themselves,
+  via #342
 
 - CI: Add codeql analysis step
 
@@ -45,6 +49,7 @@ Infrastructure updates for static type checking and doctest examples.
   - Fix CI variables
   - Rename Publish Docs -> docs
   - Fix poetry installation and caching
+
 ### Documentation
 
 - Move theme to furo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
-    "sphinx_issues",
+    "sphinx_autoissues",
     "sphinx_click.ext",  # sphinx-click
     "sphinx_inline_tabs",
     "sphinx_copybutton",
@@ -31,8 +31,6 @@ extensions = [
     "myst_parser",
 ]
 myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
-
-issues_github_path = about["__github__"].replace("https://github.com/", "")
 
 templates_path = ["_templates"]
 
@@ -84,6 +82,10 @@ html_sidebars = {
         "sidebar/scroll-end.html",
     ]
 }
+
+# sphinx-autoissues
+issuetracker = "github"
+issuetracker_project = about["__github__"].replace("https://github.com/", "")
 
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -987,22 +987,6 @@ doc = ["furo", "myst-parser"]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "sphinx-issues"
-version = "3.0.1"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "pytest (>=6.2.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
-tests = ["pytest (>=6.2.0)"]
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -1293,7 +1277,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a7db504030611d624fe9a5f856804735e3500c43d76e407eaf87869ce2a940c9"
+content-hash = "0c9f27f9ddde1861761d728ce790d5f96a7ea8ce0525a54eb9d06a065398d97d"
 
 [metadata.files]
 alabaster = [
@@ -1854,10 +1838,6 @@ sphinx-copybutton = [
 sphinx-inline-tabs = [
     {file = "sphinx_inline_tabs-2022.1.2b11-py3-none-any.whl", hash = "sha256:bb4e807769ef52301a186d0678da719120b978a1af4fd62a1e9453684e962dbc"},
     {file = "sphinx_inline_tabs-2022.1.2b11.tar.gz", hash = "sha256:afb9142772ec05ccb07f05d8181b518188fc55631b26ee803c694e812b3fdd73"},
-]
-sphinx-issues = [
-    {file = "sphinx-issues-3.0.1.tar.gz", hash = "sha256:b7c1dc1f4808563c454d11c1112796f8c176cdecfee95f0fd2302ef98e21e3d6"},
-    {file = "sphinx_issues-3.0.1-py3-none-any.whl", hash = "sha256:8b25dc0301159375468f563b3699af7a63720fd84caf81c1442036fcd418b20c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -922,6 +922,14 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
+name = "sphinx-autoissues"
+version = "0.0.1"
+description = "Sphinx integration with different issuetrackers"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -1285,7 +1293,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6c51a4447c9209846e17c5cef205598afe3ce5027f7b2284129d38189b15f304"
+content-hash = "a7db504030611d624fe9a5f856804735e3500c43d76e407eaf87869ce2a940c9"
 
 [metadata.files]
 alabaster = [
@@ -1826,6 +1834,10 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
+]
+sphinx-autoissues = [
+    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
+    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ sphinx-inline-tabs = "*"
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
+sphinx-autoissues = "*"
 myst_parser = "*"
 
 ### Testing ###
@@ -113,6 +114,7 @@ docs = [
   "sphinx-copybutton",
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
+  "sphinx-autoissues",
   "myst_parser",
   "furo",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
 sphinx-click = "*"
-sphinx-issues = "*"
 sphinx-inline-tabs = "*"
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
@@ -106,7 +105,6 @@ intersphinx = ["tqdm"]
 # Development stuff
 docs = [
   "sphinx",
-  "sphinx-issues",
   "sphinx-click",
   "sphinx-autodoc-typehints",
   "sphinx-autobuild",


### PR DESCRIPTION
https://github.com/tony/sphinx-autoissues ([Homepage](https://sphinx-autoissues.git-pull.com/))

This is a fork of [sphinxcontrib-issuetracker](https://github.com/lunaryorn/sphinxcontrib-issuetracker) but heavily modified. In the end the similarities between the packages may be less: But the major point is we want plain text issues to be linked

See also: https://github.com/tony/django-slugify-processor/pull/360