### PR TITLE
build!: Include tqdm and tldextract by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install -E "docs test coverage lint format favicon"
+          poetry install -E "docs test coverage lint format"
           poetry run pip install DJANGO~=${{ matrix.django-version }}
 
       - name: Print python versions

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,13 @@
 
 - _Add your latest changes from PRs here_
 
-## django-docutils 0.8.1 (unreleased)
+## django-docutils 0.9.0 (unreleased)
+
+### Breaking changes
+
+- `tqdm` and `tldextract` are not installed by default (#362)
+
+  This is for simplicity for the user (to note have to wrestle with sub-packages)
 
 ### Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -10,24 +10,6 @@ Install django-docutils:
 $ pip install django-docutils
 ```
 
-Favicons:
-
-```console
-$ pip install django-docutils[favicon]
-```
-
-intersphinx support:
-
-```console
-$ pip install django-docutils[intersphinx]
-```
-
-Both:
-
-```console
-$ pip install django-docutils[favicon,intersphinx]
-```
-
 ## Template filter
 
 If you want to use the template filter, add it to your `INSTALLED_APPS` in your settings file:

--- a/poetry.lock
+++ b/poetry.lock
@@ -307,7 +307,7 @@ name = "filelock"
 version = "3.8.0"
 description = "A platform independent file lock."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.extras]
@@ -842,7 +842,7 @@ name = "requests-file"
 version = "1.5.1"
 description = "File transport adapter for Requests"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -1127,7 +1127,7 @@ name = "tldextract"
 version = "3.3.1"
 description = "Accurately separates a URL's subdomain, domain, and public suffix, using the Public Suffix List (PSL). By default, this includes the public ICANN TLDs and their exceptions. You can optionally support the Public Suffix List's private domains as well."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1157,7 +1157,7 @@ name = "tqdm"
 version = "4.64.1"
 description = "Fast, Extensible Progress Meter"
 category = "main"
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
@@ -1303,16 +1303,14 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [extras]
 coverage = []
 docs = []
-favicon = ["tldextract", "tqdm"]
 format = []
-intersphinx = ["tqdm"]
 lint = []
 test = []
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "71c89dc1b88e50ba9d763c22872e09bb0d24192c7ebd80c4d20dbf8173355c80"
+content-hash = "1ea83f4702f83dd058e84161fb04065a62495670193d207fb8786edc9e28a751"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ Changes = "https://github.com/tony/django-docutils/blob/master/CHANGES"
 python = "^3.8"
 Django = ">=3.2"
 docutils = "*"
-tldextract = { version = "*", optional = true }
-tqdm = { version = "*", optional = true }
+tldextract = "*"
+tqdm = "*"
 pygments = "<3"
 django-extensions = "*"
 django-randomslugfield = "*"
@@ -101,9 +101,6 @@ types-tqdm = "^4.64.4"
 flake8-comprehensions = "^3.10.0"
 
 [tool.poetry.extras]
-favicon = ["tldextract", "tqdm"]
-intersphinx = ["tqdm"]
-
 # Development stuff
 docs = [
   "sphinx",


### PR DESCRIPTION
I'd like to make these dependencies optional but the upkeep and having them degrade gracefully + the complication involve maintaining it is burdensome.