### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,16 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from django_docutils import _internal, lib, template_tags, exc, template, views, __version__
+          from django_docutils._internal import types
+          from django_docutils.lib import directives, metadata, roles, templates, tests, transforms, publisher, settings, text, types, utils, views, writers
+          from django_docutils.templatetags import django_docutils
+          print("django_docutils version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Adds a CI check to verify runtime dependencies are correctly installed and functional before installing development dependencies.

CI:
- Adds a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.
- The check prints the package version and runs basic functionality tests.