### PR TITLE
ci(release): Migrate to PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      id-token: write
+      attestations: write
 
     strategy:
       matrix:
@@ -74,6 +77,5 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          attestations: true
+          skip-existing: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ def test_rst_tag_renders_toc_only(settings):
 ## Coding Standards
 
 - Always include `from __future__ import annotations` at the top of Python files
-- Prefer namespace imports (`import typing as t`; `import enum`) over `from module import ...`
+- Prefer namespace imports for stdlib (`import typing as t`; `import enum`); third-party packages may use `from X import Y`
 - Follow NumPy-style docstrings for functions and methods
 - Ruff enforces formatting; use `ruff format` before committing
 - Type hints are required; keep mypy strictness in mind and add `TypedDict`/`Protocol` as needed

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,10 @@ $ uvx --from 'django-docutils' --prerelease allow django-docutils
 _Upcoming changes will be written here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### CI
+
+- Migrate to PyPI Trusted Publisher (#447)
+
 ### Documentation
 
 - Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#453)

--- a/CHANGES
+++ b/CHANGES
@@ -151,8 +151,9 @@ AWS keys, and the docs build switched to the `dirhtml` builder for cleaner URLs.
 
 AGENTS.md now records the changelog conventions used by this file, working
 doctest expectations, and logging standards for future library instrumentation.
-Dev dependencies, `uv`, `just`, GitHub Actions, and gp-sphinx pins were kept
-current across the release cycle.
+Releases now publish to PyPI through a Trusted Publisher workflow (#447),
+replacing token-based authentication. Dev dependencies, `uv`, `just`, GitHub
+Actions, and gp-sphinx pins were kept current across the release cycle.
 
 ## django-docutils 0.29.0 (2025-11-01)
 


### PR DESCRIPTION
## Summary
- Migrate PyPI publishing from API token to OIDC-based Trusted Publisher
- Enable package attestations for supply chain security
- Fix deprecated `skip_existing` parameter

## Setup Required
Before merging, configure the trusted publisher on PyPI:
1. Visit: https://pypi.org/manage/project/django-docutils/settings/publishing/
2. Add publisher with:
   - Owner: `tony`
   - Repository: `django-docutils`
   - Workflow: `tests.yml`