### PR TITLE
docs: onboarding orientation and What is docutils explainer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -144,6 +144,13 @@ Django's security overview. {func}`~django_docutils.lib.sanitize.sanitize_doctre
 and {class}`~django_docutils.lib.sanitize.SanitizeTransform` are documented for
 reuse in custom docutils pipelines.
 
+A new {ref}`what-is-docutils` topic orients readers who are new to the
+ecosystem: docutils versus reStructuredText versus Sphinx, Markdown parsing
+options, and the formats docutils can emit. The README and {ref}`quickstart`
+link the upstream reStructuredText primers, and the README's unsafe-settings
+example shows the `allow_unsafe_docutils_settings` opt-in instead of a
+standalone `raw_enabled` that the hardened defaults would ignore.
+
 Documentation deployment now uses AWS OIDC authentication instead of long-lived
 AWS keys, and the docs build switched to the `dirhtml` builder for cleaner URLs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # django-docutils &middot; [![Python Package](https://img.shields.io/pypi/v/django-docutils.svg)](https://pypi.org/project/django-docutils/) [![License](https://img.shields.io/github/license/tony/django-docutils.svg)](https://github.com/tony/django-docutils/blob/master/LICENSE)
 
-docutils (a.k.a. reStructuredText / rst / reST) support for Django.
+[docutils](https://docutils.sourceforge.io/) (a.k.a.
+[reStructuredText](https://docutils.sourceforge.io/rst.html) / rst / reST)
+support for Django.
+
+Documentation: <https://django-docutils.git-pull.com/>
 
 django-docutils turns off docutils features that are risky on the web — raw
 HTML pass-through, file inclusion, and local `docutils.conf` lookup — and
@@ -34,16 +38,15 @@ In your template:
 ```django
 {% load django_docutils %}
 {% rst %}
-# hey
-# how's it going
-A. hows
-B. it
+Welcome
+=======
 
-C. going
-D. today
+Write `reStructuredText <https://docutils.sourceforge.io/rst.html>`_ with
+links, **bold** text, and highlighted code:
 
-**hi**
-*hi*
+.. code-block:: python
+
+   print("hello")
 {% endrst %}
 ```
 
@@ -54,16 +57,15 @@ In your template:
 ```django
 {% load django_docutils %}
 {% filter rst %}
-# hey
-# how's it going
-A. hows
-B. it
+Welcome
+=======
 
-C. going
-D. today
+Write `reStructuredText <https://docutils.sourceforge.io/rst.html>`_ with
+links, **bold** text, and highlighted code:
 
-**hi**
-*hi*
+.. code-block:: python
+
+   print("hello")
 {% endfilter %}
 ```
 
@@ -143,6 +145,15 @@ DJANGO_DOCUTILS_LIB_RST = {
 
 - Python 3.10+
 - Django 4.2+
+- [Documentation](https://django-docutils.git-pull.com/) ·
+  [Quickstart](https://django-docutils.git-pull.com/quickstart.html) ·
+  [Security](https://django-docutils.git-pull.com/topics/security.html) ·
+  [FAQ](https://django-docutils.git-pull.com/topics/faq.html)
+- New to the ecosystem? [What is docutils?](https://django-docutils.git-pull.com/topics/what_is_docutils.html)
+  untangles docutils, reStructuredText, Sphinx, and Markdown.
+- [reStructuredText primer](https://docutils.sourceforge.io/docs/user/rst/quickstart.html)
+  and [quick reference](https://docutils.sourceforge.io/docs/user/rst/quickref.html)
+  from the docutils project.
 
 [![Docs](https://github.com/tony/django-docutils/workflows/docs/badge.svg)](https://github.com/tony/django-docutils/actions?query=workflow%3A%22Docs%22)
 [![Build Status](https://github.com/tony/django-docutils/workflows/tests/badge.svg)](https://github.com/tony/django-docutils/actions?query=workflow%3A%22tests%22)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,6 +74,19 @@ via trunk (can break easily):
 [uv]: https://docs.astral.sh/uv/
 [uvx]: https://docs.astral.sh/uv/guides/tools/
 
+## New to reStructuredText?
+
+[reStructuredText] is the markup language; [docutils] is the library that
+parses and renders it. The official [primer][rst-primer] and
+[quick reference][rst-quickref] cover the syntax; {ref}`what-is-docutils`
+maps the wider ecosystem (docutils, Sphinx, Markdown), and the {ref}`faq`
+answers common questions.
+
+[reStructuredText]: https://docutils.sourceforge.io/rst.html
+[docutils]: https://docutils.sourceforge.io/
+[rst-primer]: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
+[rst-quickref]: https://docutils.sourceforge.io/docs/user/rst/quickref.html
+
 ## Add the django app
 
 Next, add `django_docutils` to your `INSTALLED_APPS` in your settings file:
@@ -94,4 +107,5 @@ Integrate docutils to your django site:
 3. {ref}`class_based_view`
 4. {ref}`security`
 
-:::
+The rendering defaults disable docutils features that are risky on the web;
+if your site accepts user-authored markup, start with {ref}`security`.

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -4,17 +4,26 @@
 
 ## General
 
+New to the ecosystem? {ref}`what-is-docutils` maps docutils,
+reStructuredText, Sphinx, and Markdown in one page.
+
 ### What is reST, RST, reStructuredText?
 
-[reStructuredText] is a markup syntax, similar to markdown.
+[reStructuredText] is a markup syntax, similar to markdown. Learn it from the
+official [primer][rst-primer] and [quick reference][rst-quickref].
+
+[rst-primer]: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
+[rst-quickref]: https://docutils.sourceforge.io/docs/user/rst/quickref.html
 
 ### What is docutils?
 
 [docutils] is a python package for parsing and publishing markup. The default docutils package
-supports reStructuredText. It can also be extended to parse markdown
-(e.g. [myst-parser]).
+supports reStructuredText. It can also parse markdown when a third-party
+parser such as [myst-docutils] or [myst-parser] is installed — see
+{ref}`what-is-docutils` for the details.
 
-[myst-parser]: https://github.com/executablebooks/MyST-Parser
+[myst-docutils]: https://pypi.org/project/myst-docutils/
+[myst-parser]: https://myst-parser.readthedocs.io/
 
 ## Django Docutils
 

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -31,6 +31,12 @@ Serve RST-backed pages with `DocutilsView`.
 Understand locked-down defaults and trusted-content opt-ins.
 :::
 
+:::{grid-item-card} What is docutils?
+:link: what_is_docutils
+:link-type: doc
+Untangle docutils, reStructuredText, Sphinx, and Markdown.
+:::
+
 :::{grid-item-card} FAQ
 :link: faq
 :link-type: doc
@@ -46,5 +52,6 @@ template_tag
 template_filter
 class_based_view
 security
+what_is_docutils
 faq
 ```

--- a/docs/topics/what_is_docutils.md
+++ b/docs/topics/what_is_docutils.md
@@ -1,0 +1,94 @@
+(what-is-docutils)=
+
+# What is docutils?
+
+A field guide to the names you will meet when rendering markup in Django:
+[docutils], [reStructuredText], [Sphinx], and friends — and where
+django-docutils fits among them.
+
+## What is reStructuredText?
+
+[reStructuredText] (also written *reST*, *RST*, or *rst*) is a plaintext
+markup language, comparable to Markdown but older and more extensible. The
+fastest ways in are the official [primer][rst-primer] and the
+[quick reference][rst-quickref].
+
+## What is docutils?
+
+[docutils] is the Python library that parses reStructuredText and publishes it
+to other formats. reStructuredText is the language; docutils is the processing
+system — the parser is one docutils component, the output writers are others.
+The [docutils documentation][docutils-docs] covers both halves.
+
+## What is Sphinx — and is django-docutils Sphinx?
+
+[Sphinx] is a documentation generator built on top of docutils: it adds
+cross-references, multi-page projects, themes, and extensions, and it renders
+sites like the [Python documentation](https://docs.python.org/). Its
+[reStructuredText primer][sphinx-primer] is another good introduction.
+
+django-docutils is not Sphinx. It renders RST fragments and pages inside
+Django templates and views:
+
+| Tool            | Built on          | Use it for                              |
+| --------------- | ----------------- | --------------------------------------- |
+| [docutils]      | —                 | Parsing and rendering single documents  |
+| [Sphinx]        | docutils          | Documentation sites and books           |
+| [MyST-Parser]   | docutils / Sphinx | Markdown in docutils and Sphinx         |
+| django-docutils | docutils + Django | RST inside Django templates and views   |
+
+## Can docutils parse Markdown?
+
+Yes — since docutils 0.19, with a third-party parser installed:
+[myst-docutils] (recommended) or [pycmark]. docutils selects them through its
+`markdown` / `commonmark` parser aliases — see the
+[docutils configuration reference][docutils-config]. The older
+[recommonmark](https://pypi.org/project/recommonmark/) wrapper is deprecated
+and will be removed in docutils 1.0.
+
+django-docutils itself renders reStructuredText. To serve
+[CommonMark](https://commonmark.org/) Markdown in a docutils or Sphinx
+pipeline, reach for [MyST-Parser].
+
+## What can docutils output?
+
+reStructuredText input can leave docutils in many formats — django-docutils
+uses the HTML writer family, the rest come with the
+[docutils CLI tools][docutils-tools] such as `rst2html5`, `rst2latex`, and
+`rst2man`:
+
+| Writer                       | Output                                  |
+| ---------------------------- | --------------------------------------- |
+| `html5`                      | HTML5                                   |
+| `html4css1`                  | XHTML 1.0 (the `html` default for now)  |
+| `latex2e`, `xetex`           | LaTeX / XeTeX, typically en route to PDF |
+| `manpage`                    | Unix man pages                          |
+| `odf_odt`                    | OpenDocument text (LibreOffice)         |
+| `s5_html`                    | S5 HTML slideshows                      |
+| `docutils_xml`, `pseudoxml`  | Document-tree XML / debugging output    |
+
+## Where does django-docutils fit?
+
+Your template or view hands RST source to django-docutils — via
+{ref}`template_tag`, {ref}`template_filter`, or {ref}`class_based_view` —
+which runs the docutils parser with hardened settings, removes raw nodes and
+unsafe link targets from the document tree, and returns HTML produced by
+docutils' HTML writers.
+
+Rendering user-authored markup carries risk that configuration can reduce,
+not remove — see {ref}`security` and docutils' own
+[security guide][docutils-security].
+
+[docutils]: https://docutils.sourceforge.io/
+[docutils-docs]: https://docutils.sourceforge.io/docs/
+[docutils-config]: https://docutils.sourceforge.io/docs/user/config.html
+[docutils-tools]: https://docutils.sourceforge.io/docs/user/tools.html
+[docutils-security]: https://docutils.sourceforge.io/docs/howto/security.html
+[reStructuredText]: https://docutils.sourceforge.io/rst.html
+[rst-primer]: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
+[rst-quickref]: https://docutils.sourceforge.io/docs/user/rst/quickref.html
+[Sphinx]: https://www.sphinx-doc.org/
+[sphinx-primer]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+[MyST-Parser]: https://myst-parser.readthedocs.io/
+[myst-docutils]: https://pypi.org/project/myst-docutils/
+[pycmark]: https://pypi.org/project/pycmark/


### PR DESCRIPTION
## Summary

- **Add** a {ref}`what-is-docutils` concepts topic that orients readers new to the ecosystem — docutils vs reStructuredText vs Sphinx, whether docutils can parse Markdown, and the output formats docutils can emit — with links throughout to the upstream primers and references.
- **Link** the documentation site and the upstream reStructuredText primer/quick-reference from the README, and replace the placeholder `{% rst %}` / `rst` filter examples with realistic snippets (heading, link, bold, highlighted code block).
- **Point** newcomers from the quickstart and FAQ to the primers and the concepts topic.

This is reader orientation only — no code changes. It was split out of the security fix (#457, now merged) to keep that PR focused.

## Changes by area

- **`docs/topics/what_is_docutils.md`** (new): Q&A explainer mapping docutils, reStructuredText, Sphinx, and Markdown, with a comparison table and the docutils output-writer family; added to the topics nav and toctree.
- **`README.md`**: links docutils and reStructuredText in the opening line, adds the documentation-site URL, realistic tag/filter samples, and a "More information" block linking docs/security/FAQ and the upstream primers.
- **`docs/quickstart.md`**: a short "New to reStructuredText?" pointer block (primer, quick reference, the concepts topic, FAQ).
- **`docs/topics/faq.md`**: primer/quick-reference links on the reST answer, a myst-docutils pointer on the Markdown answer, and a trail to the concepts topic.

## Context

Built on the security fix (#457, merged): the concepts topic and quickstart cross-link {ref}`security`, which that change introduced. Rebased onto `master`.

## Test plan

- [x] `just build-docs` — clean build (no warnings); the new topic renders and its nav card and toctree entry resolve
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — full suite green (doc-link changes only)

