### PR TITLE
docs(dx): Test docs examples

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -61,14 +61,12 @@ make the common case pay a comprehension tax for the advanced one.
 
 ## Examples that run
 
-`testpaths` includes `docs/`, so pytest collects any `>>>` block in a
-docs page as a doctest (gp-libs' docutils doctest tooling) and runs
-it. No `conftest.py` adds `doctest_namespace` fixtures, so spell out
-imports in the example itself (`from django_docutils.lib.publisher
-import publish_html_from_source`); pytest-django supplies
-`DJANGO_SETTINGS_MODULE=tests.settings`, so rendering helpers work.
-`ELLIPSIS` and `NORMALIZE_WHITESPACE` are already on via
-`doctest_optionflags`.
+Sphinx doctest examples run through `just -f docs/justfile doctest`, and
+autodoc examples receive the imports configured in `docs/conf.py`. Pytest does
+not collect Markdown pages by itself; fenced examples that cannot be doctested
+belong in focused tests under `tests/`, such as the docs-snippet contract tests.
+When a docs page uses a `>>>` example, spell out any imports that are not in the
+Sphinx doctest global setup.
 
 Most examples in these docs never execute: fenced `django` template
 blocks, settings dicts, and rendered-HTML output are prose to pytest.
@@ -135,6 +133,6 @@ scheme lists left exact. Read it before reshaping another page.
 - Are the advanced and pipeline-level parts clearly marked opt-in?
 - Did you leave every settings block, output block, table, and
   cross-reference exact — and do any `>>>` examples pass
-  `uv run pytest docs`?
+  `just -f docs/justfile doctest`?
 - Did `just build-docs` stay clean — no new warning, no broken
   cross-reference?

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -27,7 +27,9 @@ Exception definitions for django-docutils.
 :::{grid-item-card} Lib
 :link: lib/index
 :link-type: doc
-Publisher, roles, directives, writers, and transforms.
+{ref}`Publisher helpers <api_lib_publisher>`, {ref}`roles <api_lib_roles>`,
+{ref}`directives <api_lib_directives>`, {ref}`writers <api_lib_writers>`, and
+{ref}`transforms <api_lib_transforms>`.
 :::
 
 :::{grid-item-card} Template Engine

--- a/docs/api/lib/components.md
+++ b/docs/api/lib/components.md
@@ -60,6 +60,11 @@ Registered under the name configured in `DJANGO_DOCUTILS_LIB_RST`
 {func}`django_docutils.lib.directives.code.register_pygments_directive`. Full API: {ref}`api_lib_directives_code`.
 
 ```{eval-rst}
+.. rst:directive:: code-block
+
+   Default registered name for
+   :class:`django_docutils.lib.directives.code.CodeBlock`.
+
 .. autodirective:: django_docutils.lib.directives.code.CodeBlock
 ```
 
@@ -71,9 +76,23 @@ actually registered with docutils come from the `roles` mapping in
 Full API: {ref}`api_lib_roles`.
 
 ```{eval-rst}
+.. rst:role:: gh
+
+   Common local alias for :rst:role:`github`.
+
+.. rst:role:: hn
+
+   Common local alias for :rst:role:`hackernews`.
+
+.. rst:role:: rtd
+
+   Common local alias for :rst:role:`readthedocs`.
+
 .. autorole:: django_docutils.lib.roles.email.email_role
 
 .. autorole:: django_docutils.lib.roles.file.file_role
+
+.. autorole:: django_docutils.lib.roles.file.exe_role
 
 .. autorole:: django_docutils.lib.roles.file.manifest_role
 

--- a/docs/api/lib/directives/code.md
+++ b/docs/api/lib/directives/code.md
@@ -4,7 +4,7 @@
 
 :::{seealso}
 
-Registry-aware entry: {rst:dir}`codeblock` in
+Registry-aware entry: {rst:dir}`code-block` in
 {ref}`api_lib_components`.
 
 :::

--- a/docs/api/lib/index.md
+++ b/docs/api/lib/index.md
@@ -13,6 +13,7 @@ roles/index
 sanitize
 settings
 text
+types
 transforms/index
 utils
 views

--- a/docs/api/lib/roles/file.md
+++ b/docs/api/lib/roles/file.md
@@ -4,8 +4,8 @@
 
 :::{seealso}
 
-Registry-aware entries: {rst:role}`file` and {rst:role}`manifest` in
-{ref}`api_lib_components`.
+Registry-aware entries: {rst:role}`file`, {rst:role}`exe`, and
+{rst:role}`manifest` in {ref}`api_lib_components`.
 
 :::
 

--- a/docs/api/lib/roles/github.md
+++ b/docs/api/lib/roles/github.md
@@ -4,7 +4,8 @@
 
 :::{seealso}
 
-Registry-aware entry: {rst:role}`github` in {ref}`api_lib_components`.
+Registry-aware entries: {rst:role}`github` and common alias {rst:role}`gh` in
+{ref}`api_lib_components`.
 
 :::
 

--- a/docs/api/lib/roles/hackernews.md
+++ b/docs/api/lib/roles/hackernews.md
@@ -4,7 +4,8 @@
 
 :::{seealso}
 
-Registry-aware entry: {rst:role}`hackernews` in {ref}`api_lib_components`.
+Registry-aware entries: {rst:role}`hackernews` and common alias
+{rst:role}`hn` in {ref}`api_lib_components`.
 
 :::
 

--- a/docs/api/lib/roles/readthedocs.md
+++ b/docs/api/lib/roles/readthedocs.md
@@ -4,7 +4,8 @@
 
 :::{seealso}
 
-Registry-aware entry: {rst:role}`readthedocs` in {ref}`api_lib_components`.
+Registry-aware entries: {rst:role}`readthedocs` and common alias
+{rst:role}`rtd` in {ref}`api_lib_components`.
 
 :::
 

--- a/docs/api/lib/settings.md
+++ b/docs/api/lib/settings.md
@@ -2,6 +2,9 @@
 
 # `lib.settings`
 
+Settings helpers expose the active configuration used by the publisher and
+sanitizer. The structured settings shapes live in {ref}`api_lib_types`.
+
 ```{eval-rst}
 .. automodule:: django_docutils.lib.settings
    :members:

--- a/docs/api/lib/types.md
+++ b/docs/api/lib/types.md
@@ -1,0 +1,13 @@
+(api_lib_types)=
+
+# `lib.types`
+
+Typed settings dictionaries for django-docutils configuration. See
+{ref}`api_lib_settings` for the live settings objects that use these types.
+
+```{eval-rst}
+.. automodule:: django_docutils.lib.types
+   :members:
+   :show-inheritance:
+   :member-order: bysource
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ conf = merge_sphinx_config(
     light_logo="img/icons/logo.svg",
     dark_logo="img/icons/logo-dark.svg",
     extra_extensions=[
+        "sphinx.ext.doctest",
         "sphinx_autodoc_api_style",
         "sphinx_autodoc_docutils",
         "sphinx_autodoc_sphinx",
@@ -60,3 +61,51 @@ conf = merge_sphinx_config(
     exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
 )
 globals().update(conf)
+
+doctest_global_setup = """
+from docutils import nodes
+from django_docutils.lib.publisher import (
+    publish_doctree,
+    publish_html_from_doctree,
+    publish_html_from_source,
+    publish_parts_from_doctree,
+)
+from django_docutils.lib.roles.kbd import kbd_role
+from django_docutils.lib.sanitize import (
+    SanitizeTransform,
+    _remove_node,
+    _replace_node_with_text,
+    _uri_is_allowed,
+    sanitize_doctree,
+)
+from django_docutils.lib.settings import (
+    DJANGO_DOCUTILS_LIB_RST,
+    get_allowed_uri_schemes,
+    get_docutils_settings,
+    reload_settings,
+    unsafe_docutils_settings_allowed,
+)
+from django_docutils.lib.writers import DjangoDocutilsWriter
+from django_docutils.template import DocutilsTemplate
+"""
+
+nitpick_ignore_regex = [
+    ("py:.*", r"docutils\..*"),
+    ("py:.*", r"django\..*"),
+    ("py:.*", r"pygments\..*"),
+    ("py:.*", r"typing_extensions\..*"),
+    ("py:.*", r"django_docutils\.lib\.transforms\.code\.Token(Stream|Generator)"),
+    ("py:class", r"django_docutils\.lib\.roles\.types\.RoleFnReturnValue"),
+    ("py:.*", r"nodes\..*"),
+    ("py:class", r"Formatter"),
+    ("py:class", r"HttpRequest"),
+    ("py:class", r"RoleFnReturnValue"),
+    ("py:class", r"StrPath"),
+    ("py:class", r"frozenset of str"),
+    ("py:class", r"mapping"),
+    ("py:class", r"optional"),
+    ("py:class", r"str or bytes"),
+    ("py:class", r"str or None"),
+    ("py:obj", r"From:"),
+    ("py:obj", r"License:"),
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,9 @@ Install and render your first RST snippet in 5 minutes.
 :::{grid-item-card} Topics
 :link: topics/index
 :link-type: doc
-Template tags, template filters, class-based views, security, and FAQ.
+{ref}`Template tag <template_tag>`, {ref}`class-based view <class_based_view>`,
+{ref}`security`, legacy {ref}`template filter <template_filter>`, and
+{ref}`FAQ <faq>`.
 :::
 
 :::{grid-item-card} API Reference

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -18,7 +18,15 @@ Install packages:
 $ uv sync --all-extras --dev
 ```
 
-## Running Tests
+## Codebase map
+
+The Django-facing entry points are the template tag and filter in
+`django_docutils.templatetags.django_docutils`, the template backend in
+`django_docutils.template`, and `DocutilsView` in `django_docutils.views`.
+They all hand source to the publisher helpers in `django_docutils.lib`, where
+roles, directives, transforms, writers, settings, and sanitization are applied.
+
+## Running tests
 
 ```console
 $ uv run pytest
@@ -36,14 +44,31 @@ Watch tests:
 $ uv run ptw .
 ```
 
-## Building Docs
+## Building docs
 
 ```console
-$ uv run sphinx-build docs docs/_build
+$ just build-docs
 ```
 
-Live-reload:
+Run Sphinx doctests:
 
 ```console
-$ uv run sphinx-autobuild docs docs/_build
+$ just -f docs/justfile doctest
+```
+
+Live reload:
+
+```console
+$ just start-docs
+```
+
+Before committing, run the full local gate from the repository root:
+
+```console
+$ rm -rf docs/_build
+$ uv run ruff check . --fix --show-fixes
+$ uv run ruff format .
+$ uv run mypy .
+$ uv run py.test --reruns 0 -vvv
+$ just build-docs
 ```

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -17,7 +17,7 @@ publishing.
 3. Commit:
 
    ```console
-   $ git commit -m "django-docutils <version>"
+   $ git commit -m "Tag v<version>"
    ```
 
 4. Tag:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,23 +31,10 @@ general availability.
   $ pip install --upgrade --pre django-docutils
   ```
 
-- [pipx]\:
-
-  ```console
-  $ pipx install --suffix=@next 'django-docutils' --pip-args '\--pre' --force
-  // Usage: django-docutils@next
-  ```
-
 - [uv]\:
 
   ```console
   $ uv add django-docutils --prerelease allow
-  ```
-
-- [uvx]\:
-
-  ```console
-  $ uvx --from 'django-docutils' --prerelease allow django-docutils
   ```
 
 via trunk (can break easily):
@@ -58,23 +45,15 @@ via trunk (can break easily):
   $ pip install -e git+https://github.com/tony/django-docutils.git#egg=django-docutils
   ```
 
-- [pipx]\:
-
-  ```console
-  $ pipx install --suffix=@master 'django-docutils @ git+https://github.com/tony/django-docutils.git@master' --force
-  ```
-
 - [uv]\:
 
   ```console
-  $ uv tool install django-docutils --from git+https://github.com/tony/django-docutils.git
+  $ uv add django-docutils --from git+https://github.com/tony/django-docutils.git
   ```
 
 [pip]: https://pip.pypa.io/en/stable/
-[pipx]: https://pypa.github.io/pipx/docs/
 [PyPI]: https://pypi.org/
 [uv]: https://docs.astral.sh/uv/
-[uvx]: https://docs.astral.sh/uv/guides/tools/
 
 ## New to reStructuredText?
 
@@ -103,14 +82,39 @@ INSTALLED_APPS = [
 ]
 ```
 
+## Render your first block
+
+Load the template tags and put a small reStructuredText document inside
+`{% rst %}`:
+
+```django
+{% load django_docutils %}
+{% rst %}
+Hello
+=====
+
+Welcome to **reStructuredText** in Django.
+{% endrst %}
+```
+
+Output:
+
+```html
+<main id="hello">
+<h1 class="title is-1">Hello</h1>
+<p>Welcome to <strong>reStructuredText</strong> in Django.</p>
+</main>
+```
+
 ## Next steps
 
 Choose the entry point for your Django site:
 
 1. {ref}`template_tag`
-2. {ref}`template_filter`
-3. {ref}`class_based_view`
-4. {ref}`security`
+2. {ref}`class_based_view`
+3. {ref}`security`
+4. {ref}`template_filter` for legacy templates that already use the deprecated
+   filter
 
 The rendering defaults disable docutils features that are risky on the web;
 if your site accepts user-authored markup, start with {ref}`security`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ via trunk (can break easily):
 - [uv]\:
 
   ```console
-  $ uv add django-docutils --from git+https://github.com/tony/django-docutils.git
+  $ uv add "django-docutils @ git+https://github.com/tony/django-docutils.git"
   ```
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -17,8 +17,8 @@ Render [reStructuredText] inside [Django] templates with the
 :::{grid-item-card} Template Filter
 :link: template_filter
 :link-type: doc
-Use the {func}`~django_docutils.templatetags.django_docutils.rst_filter` filter
-to convert RST strings to HTML inline.
+Legacy coverage for the deprecated
+{func}`~django_docutils.templatetags.django_docutils.rst_filter` filter.
 :::
 
 :::{grid-item-card} Class-based View

--- a/docs/topics/template_filter.md
+++ b/docs/topics/template_filter.md
@@ -2,9 +2,9 @@
 
 # Template filter
 
-Use {func}`~django_docutils.templatetags.django_docutils.rst_filter` when
-[reStructuredText] source flows through [Django]'s filter syntax, either as a
-variable or a `{% filter rst %}` block.
+The {func}`~django_docutils.templatetags.django_docutils.rst_filter` filter is
+deprecated. Keep it for existing templates that already use [Django]'s filter
+syntax, but use {ref}`template_tag` for new template blocks.
 
 :::{seealso}
 
@@ -41,8 +41,12 @@ In your HTML template:
 ```django
 {% load django_docutils %}
 {% filter rst %}
-# hey
-# how's it going
+hey
+---
+
+hi
+##
+
 A. hows
 B. it
 

--- a/docs/topics/template_tag.md
+++ b/docs/topics/template_tag.md
@@ -42,8 +42,12 @@ In your HTML template:
 ```django
 {% load django_docutils %}
 {% rst %}
-# hey
-# how's it going
+hey
+---
+
+hi
+##
+
 A. hows
 B. it
 

--- a/docs/topics/what_is_docutils.md
+++ b/docs/topics/what_is_docutils.md
@@ -17,8 +17,9 @@ fastest ways in are the official [primer][rst-primer] and the
 
 [docutils] is the Python library that parses reStructuredText and publishes it
 to other formats. reStructuredText is the language; docutils is the processing
-system — the parser is one docutils component, the output writers are others.
-The [docutils documentation][docutils-docs] covers both halves.
+system — the [parser][docutils-parser] is one docutils component, the
+[output writers][docutils-writers] are others. The
+[docutils documentation][docutils-docs] covers both halves.
 
 ## What is Sphinx — and is django-docutils Sphinx?
 
@@ -53,7 +54,7 @@ pipeline, reach for [MyST-Parser].
 ## What can docutils output?
 
 reStructuredText input can leave docutils in many formats — django-docutils
-uses the HTML writer family, the rest come with the
+uses the [HTML writer family][docutils-html-writer], the rest come with the
 [docutils CLI tools][docutils-tools] such as `rst2html5`, `rst2latex`, and
 `rst2man`:
 
@@ -82,6 +83,9 @@ not remove — see {ref}`security` and docutils' own
 [docutils]: https://docutils.sourceforge.io/
 [Django]: https://docs.djangoproject.com/
 [docutils-docs]: https://docutils.sourceforge.io/docs/
+[docutils-parser]: https://docutils.sourceforge.io/docs/ref/doctree.html
+[docutils-writers]: https://docutils.sourceforge.io/docs/api/publisher.html#publishers
+[docutils-html-writer]: https://docutils.sourceforge.io/docs/user/html.html
 [docutils-config]: https://docutils.sourceforge.io/docs/user/config.html
 [docutils-tools]: https://docutils.sourceforge.io/docs/user/tools.html
 [docutils-security]: https://docutils.sourceforge.io/docs/howto/security.html

--- a/src/django_docutils/lib/roles/common.py
+++ b/src/django_docutils/lib/roles/common.py
@@ -27,16 +27,19 @@ def generic_url_role(
 
     Parameters
     ----------
-    name : name of the role, e.g. 'github'
-    text : text inside of the role, e.g:
+    name : str
+        Name of the role, e.g. ``github``.
+    text : str
+        Text inside of the role, e.g:
+
       - 'airline-mode/airline-mode'
       - 'this repo <airline-mode/airline-mode>'
-    url_handler_fn : :data:`django_docutils.lib.roles.types.UrlHandlerFn`
-      a function that accepts the target param
+    url_handler_fn : django_docutils.lib.roles.types.UrlHandlerFn
+        A function that accepts the target param.
 
     Returns
     -------
-    :data:`django_docutils.lib.roles.types.RoleFnReturnValue`
+    django_docutils.lib.roles.types.RoleFnReturnValue
 
     Examples
     --------
@@ -94,16 +97,19 @@ def generic_remote_url_role(
 
     Parameters
     ----------
-    name : name of the role, e.g. 'github'
-    text : text inside of the role, e.g:
+    name : str
+        Name of the role, e.g. ``github``.
+    text : str
+        Text inside of the role, e.g:
+
       - 'airline-mode/airline-mode'
       - 'this repo <airline-mode/airline-mode>'
-    url_handler_fn : :data:`django_docutils.lib.roles.types.RemoteUrlHandlerFn`
-       a function that accepts the target param, example:
+    url_handler_fn : django_docutils.lib.roles.types.RemoteUrlHandlerFn
+        A function that accepts the target param.
 
     Returns
     -------
-    :data:`django_docutils.lib.roles.types.RoleFnReturnValue`
+    django_docutils.lib.roles.types.RoleFnReturnValue
 
     Examples
     --------

--- a/src/django_docutils/lib/sanitize.py
+++ b/src/django_docutils/lib/sanitize.py
@@ -161,7 +161,7 @@ def sanitize_doctree(
 
 
 class SanitizeTransform(Transform):
-    """Run :func:`sanitize_doctree` as a docutils transform.
+    """Run :func:`~django_docutils.lib.sanitize.sanitize_doctree` as a transform.
 
     :class:`~django_docutils.lib.writers.DjangoDocutilsWriter` sanitizes in
     ``translate()`` so the pass always runs after every transform. This

--- a/src/django_docutils/lib/text.py
+++ b/src/django_docutils/lib/text.py
@@ -25,9 +25,10 @@ def is_uncapitalized_word(value: str) -> bool:
         True if term or word is uncapitalized.
 
 
-    Functions can be declared via DJANGO_DOCUTILS_TEXT in django settings via string
-    imports. The filters accept one argument (the word). If you don't want the
-    word/pattern capitalized, return True. Anything else capitalizes as normal.
+    Functions can be declared via ``DJANGO_DOCUTILS_LIB_TEXT`` in Django
+    settings via string imports. The filters accept one argument (the word). If
+    you don't want the word or pattern capitalized, return ``True``. Anything
+    else capitalizes as normal.
 
     How to create filters:
 

--- a/src/django_docutils/lib/types.py
+++ b/src/django_docutils/lib/types.py
@@ -37,6 +37,6 @@ class DjangoDocutilsLibRSTSettings(TypedDict, total=False):
 
 
 class DjangoDocutilsLibTextSettings(TypedDict):
-    """Core settings object for ``DJANGO_DOCUTILS_TEXT_RST``."""
+    """Core settings object for ``DJANGO_DOCUTILS_LIB_TEXT``."""
 
     uncapitalized_word_filters: list[str]

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,197 @@
+"""Tests for user-facing documentation examples."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import typing as t
+
+import pytest
+from django.template import Context, Template
+
+from django_docutils.views import DocutilsResponse, DocutilsView
+
+if t.TYPE_CHECKING:
+    from django.test import RequestFactory
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_DOCS_ROOT = _REPO_ROOT / "docs"
+_FENCE_RE = re.compile(
+    r"^(?P<fence>`{3,}|~{3,})(?P<language>[^\n]*)\n"
+    r"(?P<body>.*?)"
+    r"^(?P=fence)\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+class TemplateSnippetCase(t.NamedTuple):
+    """A documented Django template example and its rendered HTML block."""
+
+    test_id: str
+    path: pathlib.Path
+    snippet_contains: str
+    expects_deprecation: bool
+
+
+class PageContractCase(t.NamedTuple):
+    """A prose-level documentation contract."""
+
+    test_id: str
+    path: pathlib.Path
+    required: tuple[str, ...]
+    forbidden: tuple[str, ...]
+
+
+TEMPLATE_SNIPPET_CASES: list[TemplateSnippetCase] = [
+    TemplateSnippetCase(
+        test_id="template-tag",
+        path=_DOCS_ROOT / "topics" / "template_tag.md",
+        snippet_contains="{% rst %}",
+        expects_deprecation=False,
+    ),
+    TemplateSnippetCase(
+        test_id="template-filter",
+        path=_DOCS_ROOT / "topics" / "template_filter.md",
+        snippet_contains="{% filter rst %}",
+        expects_deprecation=True,
+    ),
+    TemplateSnippetCase(
+        test_id="quickstart-first-block",
+        path=_DOCS_ROOT / "quickstart.md",
+        snippet_contains="{% rst %}",
+        expects_deprecation=False,
+    ),
+]
+
+PAGE_CONTRACT_CASES: list[PageContractCase] = [
+    PageContractCase(
+        test_id="quickstart-renders-first-snippet",
+        path=_DOCS_ROOT / "quickstart.md",
+        required=("{% rst %}", "Output:"),
+        forbidden=("pipx", "uvx"),
+    ),
+    PageContractCase(
+        test_id="template-filter-is-legacy",
+        path=_DOCS_ROOT / "topics" / "template_filter.md",
+        required=("deprecated", "{ref}`template_tag`"),
+        forbidden=(),
+    ),
+]
+
+
+def _read_docs_page(path: pathlib.Path) -> str:
+    """Return a docs source page."""
+    return path.read_text(encoding="utf-8")
+
+
+def _fenced_blocks(path: pathlib.Path, language: str) -> list[str]:
+    """Return fenced code blocks for ``language`` from a docs source page."""
+    return [
+        match.group("body").rstrip("\n")
+        for match in _FENCE_RE.finditer(_read_docs_page(path))
+        if match.group("language").strip() == language
+    ]
+
+
+def _first_fenced_block(path: pathlib.Path, language: str) -> str:
+    """Return the first fenced block for ``language`` from ``path``."""
+    blocks = _fenced_blocks(path, language)
+    assert blocks, f"{path} has no {language!r} fenced block"
+    return blocks[0]
+
+
+def _fenced_block_containing(path: pathlib.Path, language: str, needle: str) -> str:
+    """Return the first fenced block for ``language`` that contains ``needle``."""
+    for block in _fenced_blocks(path, language):
+        if needle in block:
+            return block
+    msg = f"{path} has no {language!r} fenced block containing {needle!r}"
+    raise AssertionError(msg)
+
+
+def _normalize_html(value: str) -> str:
+    """Normalize rendered HTML for docs example comparisons."""
+    return value.strip()
+
+
+@pytest.mark.parametrize(
+    TemplateSnippetCase._fields,
+    TEMPLATE_SNIPPET_CASES,
+    ids=[case.test_id for case in TEMPLATE_SNIPPET_CASES],
+)
+def test_template_topic_examples_render_documented_html(
+    test_id: str,
+    path: pathlib.Path,
+    snippet_contains: str,
+    expects_deprecation: bool,
+    settings: t.Any,
+) -> None:
+    """Template topic examples must render the HTML documented beside them."""
+    source = _fenced_block_containing(path, "django", snippet_contains)
+    expected_html = _first_fenced_block(path, "html")
+
+    if expects_deprecation:
+        with pytest.warns(DeprecationWarning):
+            rendered = Template(source).render(Context())
+    else:
+        rendered = Template(source).render(Context())
+
+    assert _normalize_html(rendered) == expected_html
+
+
+def test_class_based_view_example_renders_documented_html(
+    settings: t.Any,
+    tmp_path: pathlib.Path,
+    rf: RequestFactory,
+) -> None:
+    """The class-based view topic's RST example must render its shown output."""
+    path = _DOCS_ROOT / "topics" / "class_based_view.md"
+    rst_source = _first_fenced_block(path, "restructuredtext")
+    base_template = _first_fenced_block(path, "django")
+    expected_html = _first_fenced_block(path, "html")
+    request = rf.get("/")
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    settings.TEMPLATES[0].setdefault("DIRS", [str(template_dir)])
+    settings.TEMPLATES.append(
+        {
+            "NAME": "docutils",
+            "BACKEND": "django_docutils.template.DocutilsTemplates",
+            "DIRS": [str(template_dir)],
+            "APP_DIRS": True,
+        },
+    )
+    (template_dir / "base.html").write_text(base_template, encoding="utf-8")
+    (template_dir / "home.rst").write_text(rst_source, encoding="utf-8")
+
+    class HomeView(DocutilsView):
+        template_name = "base.html"
+        rst_name = "home.rst"
+
+    home_view = HomeView()
+    home_view.setup(request)
+    response = t.cast(DocutilsResponse, home_view.render_to_response())
+    response.render()
+
+    assert _normalize_html(response.content.decode("utf-8")) == expected_html
+
+
+@pytest.mark.parametrize(
+    PageContractCase._fields,
+    PAGE_CONTRACT_CASES,
+    ids=[case.test_id for case in PAGE_CONTRACT_CASES],
+)
+def test_docs_pages_follow_dx_contracts(
+    test_id: str,
+    path: pathlib.Path,
+    required: tuple[str, ...],
+    forbidden: tuple[str, ...],
+) -> None:
+    """High-traffic pages must keep reader-facing DX promises."""
+    source = _read_docs_page(path)
+
+    for text in required:
+        assert text in source
+    for text in forbidden:
+        assert text not in source


### PR DESCRIPTION
## Summary

- Add regression tests that render the documented Django template, quickstart, and class-based view examples against their shown HTML output.
- Enable Sphinx doctest support and add API coverage for `lib.types` plus registered directive and role alias targets.
- Correct RST examples, template-filter deprecation guidance, contributor docs commands, and object/Docutils links.

## Verification

- `rm -rf docs/_build`
- `uv run ruff check . --fix --show-fixes`
- `uv run ruff format .`
- `uv run mypy .`
- `uv run py.test --reruns 0 -vvv`
- `just build-docs`
- `just -f docs/justfile doctest`
- fresh strict Sphinx build with `uv run sphinx-build -n -W -b dirhtml ...`
