### PR TITLE
Fix failed import on installs without typing-extensions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Test with pytest
         run: uv run py.test --cov=./ --cov-report=xml
 
+      # Installs only [project].dependencies, so anything imported at runtime
+      # but declared in a dependency group fails here rather than on PyPI.
+      - name: Runtime dependency smoke test
+        run: >
+          uvx --isolated --no-cache
+          --python ${{ matrix.python-version }}
+          --from . python scripts/runtime_dep_smoketest.py
+
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,16 @@ $ uvx --from 'django-docutils' --prerelease allow django-docutils
 _Upcoming changes will be written here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### `typing-extensions` no longer required at runtime (#465)
+
+`typing_extensions` was imported at module scope but never declared as a runtime
+dependency, so installs without it raised `ModuleNotFoundError` on
+{class}`~django_docutils.template.DocutilsTemplates`,
+{func}`~django_docutils.templatetags.django_docutils.rst`, and
+{class}`~django_docutils.views.DocutilsView`.
+
 ### Documentation
 
 #### Documentation links now follow reader workflows
@@ -47,6 +57,14 @@ The template tag, template filter, and class-based view guides now introduce the
 feature before setup details, so readers see when to use each entry point before
 they copy configuration. The quickstart and FAQ wording was also tightened
 around Django, Python, Markdown, and developmental-release terminology.
+
+### Development
+
+#### Runtime dependency smoke test (#465)
+
+CI installs django-docutils with only its declared runtime dependencies, imports
+every module, and renders reStructuredText, so a runtime import declared only in
+a dependency group fails the build instead of reaching PyPI.
 
 ## django-docutils 0.30.0 (2026-06-07)
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+"""Root pytest configuration for django-docutils."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Skip runtime smoke tests unless explicitly requested via ``-m``.
+
+    The smoke test builds the project and resolves dependencies in a throwaway
+    environment, which is too slow for the default ``pytest`` loop. CI runs it
+    as its own step.
+    """
+    marker_name = "scripts__runtime_dep_smoketest"
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    if marker_name in markexpr:
+        return
+
+    skip_marker = pytest.mark.skip(
+        reason=f"pass -m {marker_name} to run runtime dependency smoke tests",
+    )
+    for item in items:
+        if marker_name in item.keywords:
+            item.add_marker(skip_marker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ dev = [
   "types-docutils",
   "types-Pygments",
   "types-pytz",
+  # Type-checking only: `NotRequired` / `Unpack` are 3.11+ in the stdlib and
+  # are imported under `t.TYPE_CHECKING`. Must never become a runtime dep.
+  "typing-extensions",
 ]
 
 docs = [
@@ -116,6 +119,9 @@ lint = [
   "types-docutils",
   "types-Pygments",
   "types-pytz",
+  # Type-checking only: `NotRequired` / `Unpack` are 3.11+ in the stdlib and
+  # are imported under `t.TYPE_CHECKING`. Must never become a runtime dep.
+  "typing-extensions",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,10 @@ testpaths = [
   "src/django_docutils",
   "tests",
   "docs",
+  "scripts",
+]
+markers = [
+  "scripts__runtime_dep_smoketest: run runtime dependency smoke tests",
 ]
 pythonpath = ". tests"
 filterwarnings = [

--- a/scripts/runtime_dep_smoketest.py
+++ b/scripts/runtime_dep_smoketest.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Runtime dependency smoke test for django-docutils.
+
+Imports every module in the ``django_docutils`` package and renders a small
+reStructuredText document through the public API. It is meant to run inside an
+environment that has *only* the package's runtime dependencies installed, so
+that a dependency which is declared under ``[dependency-groups]`` (or merely
+pulled in transitively by a dev tool) but imported at runtime is caught before
+release. ``typing_extensions`` is the motivating example.
+
+Run it against a clean build::
+
+    uvx --isolated --no-cache --from . python scripts/runtime_dep_smoketest.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import pkgutil
+import sys
+import typing as t
+
+ModuleName = str
+
+DEFAULT_PACKAGE = "django_docutils"
+
+SMOKE_TEST_RST = """\
+Heading
+=======
+
+Hello **world**, see :pypi:`django-docutils`.
+
+Sub one
+-------
+
+Text.
+
+Sub two
+-------
+
+.. code-block:: python
+
+   print("hi")
+"""
+"""Exercises the writer, a role, the code directive, and the TOC transform.
+
+Two sub-sections are required for the TOC transform to emit anything.
+"""
+
+
+def parse_args(argv: t.Sequence[str] | None = None) -> argparse.Namespace:
+    """Return parsed CLI arguments for the smoke test runner.
+
+    Parameters
+    ----------
+    argv : sequence of str, optional
+        Argument vector; defaults to ``sys.argv[1:]``.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments.
+
+    Examples
+    --------
+    >>> parse_args(["--skip-render"]).skip_render
+    True
+    >>> parse_args([]).package
+    'django_docutils'
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe django-docutils' runtime dependencies by importing every "
+            "module and rendering reStructuredText through the public API."
+        ),
+    )
+    parser.add_argument(
+        "--package",
+        default=DEFAULT_PACKAGE,
+        help=f"Root package to inspect (defaults to {DEFAULT_PACKAGE}).",
+    )
+    parser.add_argument(
+        "--skip-imports",
+        action="store_true",
+        help="Skip module import validation.",
+    )
+    parser.add_argument(
+        "--skip-render",
+        action="store_true",
+        help="Skip the reStructuredText render check.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print each module as it is imported.",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_django() -> None:
+    """Bootstrap Django the way a project depending on django-docutils would.
+
+    django-docutils reads ``DJANGO_DOCUTILS_LIB_RST`` at import time, so the
+    settings object must exist before any module is imported.
+
+    Roles and directives register only from ``DJANGO_DOCUTILS_LIB_RST``, and
+    docutils degrades an unregistered role or directive into an error node
+    instead of raising. Bootstrapping without them would leave the render check
+    exercising neither pygments nor the role machinery, while still passing.
+
+    Examples
+    --------
+    >>> configure_django()
+    >>> from django.conf import settings
+    >>> settings.configured
+    True
+    """
+    import django
+    from django.conf import settings
+
+    if settings.configured:
+        return
+
+    settings.configure(
+        INSTALLED_APPS=["django_docutils"],
+        TEMPLATES=[{"BACKEND": "django_docutils.template.DocutilsTemplates"}],
+        DJANGO_DOCUTILS_LIB_RST={
+            "directives": {
+                "code-block": "django_docutils.lib.directives.code.CodeBlock",
+            },
+            "roles": {
+                "local": {"pypi": "django_docutils.lib.roles.pypi.pypi_role"},
+            },
+        },
+    )
+    django.setup()
+
+
+def discover_modules(package_name: str) -> list[ModuleName]:
+    """Return a sorted list of module names within *package_name*.
+
+    Parameters
+    ----------
+    package_name : str
+        Importable root package.
+
+    Returns
+    -------
+    list of str
+        Every module in the package, including the package itself.
+
+    Examples
+    --------
+    >>> discover_modules("argparse")
+    ['argparse']
+    >>> "django_docutils.lib.publisher" in discover_modules("django_docutils")
+    True
+    """
+    package = importlib.import_module(package_name)
+    module_names: set[str] = {package_name}
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return sorted(module_names)
+    module_names.update(
+        module_info.name
+        for module_info in pkgutil.walk_packages(
+            package_path,
+            prefix=f"{package_name}.",
+        )
+    )
+    return sorted(module_names)
+
+
+def import_all_modules(module_names: list[ModuleName], verbose: bool) -> list[str]:
+    """Import each module, returning a failure message per module that raised.
+
+    Parameters
+    ----------
+    module_names : list of str
+        Modules to import.
+    verbose : bool
+        Echo each module name to stdout as it is imported.
+
+    Returns
+    -------
+    list of str
+        Failure messages; empty when every module imported.
+
+    Examples
+    --------
+    >>> import_all_modules(["argparse"], verbose=False)
+    []
+    >>> import_all_modules(["django_docutils.no_such_module"], verbose=False)
+    ['django_docutils.no_such_module: ModuleNotFoundError(...)']
+    """
+    failures: list[str] = []
+    for module_name in module_names:
+        if verbose:
+            sys.stdout.write(f"import {module_name}\n")
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            failures.append(f"{module_name}: {exc!r}")
+    return failures
+
+
+def exercise_api(verbose: bool) -> list[str]:
+    """Render reStructuredText through the public API, returning failures.
+
+    Importing a module only proves its *top-level* imports resolve. A
+    dependency imported lazily inside a function body — or a docutils
+    component registered on first use — stays invisible until something is
+    actually rendered, so exercise the public entry points here.
+
+    Parameters
+    ----------
+    verbose : bool
+        Echo each check to stdout as it runs.
+
+    Returns
+    -------
+    list of str
+        Failure messages; empty when every check passed.
+
+    Examples
+    --------
+    >>> configure_django()
+    >>> exercise_api(verbose=False)
+    []
+    """
+    from django_docutils.lib.publisher import (
+        publish_doctree,
+        publish_html_from_source,
+        publish_toc_from_doctree,
+    )
+
+    failures: list[str] = []
+
+    if verbose:
+        sys.stdout.write("render publish_html_from_source\n")
+    try:
+        html = publish_html_from_source(SMOKE_TEST_RST) or ""
+    except Exception as exc:
+        failures.append(f"publish_html_from_source: {exc!r}")
+    else:
+        # docutils renders an unregistered role or directive as an error node
+        # rather than raising, so assert on the markers each dependency leaves
+        # behind. Without them a missing dependency renders a broken document
+        # and still exits 0.
+        if "system-message" in html.lower():
+            failures.append("publish_html_from_source: docutils emitted an error node")
+        if "highlight" not in html:
+            failures.append("publish_html_from_source: pygments did not highlight")
+        if "pypi.python.org" not in html:
+            failures.append("publish_html_from_source: pypi role did not resolve")
+
+    if verbose:
+        sys.stdout.write("render publish_toc_from_doctree\n")
+    try:
+        toc = publish_toc_from_doctree(publish_doctree(SMOKE_TEST_RST))
+    except Exception as exc:
+        failures.append(f"publish_toc_from_doctree: {exc!r}")
+    else:
+        if not toc:
+            failures.append("publish_toc_from_doctree: returned no table of contents")
+
+    return failures
+
+
+def main(argv: t.Sequence[str] | None = None) -> int:
+    """Entry point for the runtime dependency smoke test.
+
+    Parameters
+    ----------
+    argv : sequence of str, optional
+        Argument vector; defaults to ``sys.argv[1:]``.
+
+    Returns
+    -------
+    int
+        ``0`` when every check passed, ``1`` otherwise.
+
+    Examples
+    --------
+    >>> main(["--package", "argparse", "--skip-render"])
+    0
+    """
+    args = parse_args(argv)
+    failures: list[str] = []
+
+    configure_django()
+
+    if not args.skip_imports:
+        try:
+            modules = discover_modules(args.package)
+        except Exception as exc:
+            failures.append(f"{args.package}: {exc!r}")
+        else:
+            failures.extend(import_all_modules(modules, args.verbose))
+
+    if not args.skip_render:
+        failures.extend(exercise_api(args.verbose))
+
+    if failures:
+        for failure in failures:
+            sys.stderr.write(f"{failure}\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_runtime_dep_smoketest.py
+++ b/scripts/test_runtime_dep_smoketest.py
@@ -1,0 +1,55 @@
+"""Tests for the runtime dependency smoke test script.
+
+These tests are isolated behind the ``scripts__runtime_dep_smoketest`` marker so
+they only run when explicitly requested, e.g.
+``pytest -m scripts__runtime_dep_smoketest``. Each one builds the project into a
+throwaway environment, which is far too slow for the default loop.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.scripts__runtime_dep_smoketest
+
+
+def test_runtime_smoke_test_script() -> None:
+    """Run ``scripts/runtime_dep_smoketest.py`` in a clean uvx environment.
+
+    ``--isolated --no-cache --from .`` installs the project with only its
+    ``[project].dependencies``, so anything imported at runtime but declared in
+    a dependency group fails here.
+    """
+    uvx = shutil.which("uvx")
+    if uvx is None:
+        pytest.skip("uvx is required to run the runtime dependency smoke test")
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "runtime_dep_smoketest.py"
+
+    result = subprocess.run(
+        [
+            uvx,
+            "--isolated",
+            "--no-cache",
+            "--from",
+            str(repo_root),
+            "python",
+            str(script_path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        check=False,
+    )
+
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+
+    assert result.returncode == 0, "runtime dependency smoke test failed"

--- a/src/django_docutils/lib/publisher.py
+++ b/src/django_docutils/lib/publisher.py
@@ -9,7 +9,6 @@ from django.utils.safestring import mark_safe
 from docutils import io, nodes
 from docutils.core import Publisher, publish_doctree as docutils_publish_doctree
 from docutils.readers.doctree import Reader
-from typing_extensions import NotRequired, TypedDict, Unpack
 
 from .directives.registry import register_django_docutils_directives
 from .roles.registry import register_django_docutils_roles
@@ -17,6 +16,9 @@ from .sanitize import sanitize_doctree
 from .settings import get_docutils_settings
 from .transforms.toc import Contents
 from .writers import DjangoDocutilsWriter
+
+if t.TYPE_CHECKING:
+    from typing_extensions import NotRequired, Unpack
 
 
 def publish_parts_from_doctree(
@@ -181,7 +183,7 @@ def publish_doctree(
     )
 
 
-class PublishHtmlDocTreeKwargs(TypedDict):
+class PublishHtmlDocTreeKwargs(t.TypedDict):
     """Keyword arguments accepted by publish_html_from_source."""
 
     show_title: NotRequired[bool]

--- a/src/django_docutils/lib/types.py
+++ b/src/django_docutils/lib/types.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 import typing as t
 
-from typing_extensions import TypedDict
 
-
-class DjangoDocutilsLibRSTRolesSettings(TypedDict, total=False):
+class DjangoDocutilsLibRSTRolesSettings(t.TypedDict, total=False):
     """Docutils role mappings."""
 
     local: dict[str, str]
 
 
-class DjangoDocutilsLibRSTDocutilsSettings(TypedDict, total=False):
+class DjangoDocutilsLibRSTDocutilsSettings(t.TypedDict, total=False):
     """Docutils document settings."""
 
     file_insertion_enabled: bool
@@ -24,7 +22,7 @@ class DjangoDocutilsLibRSTDocutilsSettings(TypedDict, total=False):
     initial_header_level: int
 
 
-class DjangoDocutilsLibRSTSettings(TypedDict, total=False):
+class DjangoDocutilsLibRSTSettings(t.TypedDict, total=False):
     """Core settings object for ``DJANGO_DOCUTILS_LIB_RST``."""
 
     allow_unsafe_docutils_settings: bool
@@ -36,7 +34,7 @@ class DjangoDocutilsLibRSTSettings(TypedDict, total=False):
     roles: DjangoDocutilsLibRSTRolesSettings
 
 
-class DjangoDocutilsLibTextSettings(TypedDict):
+class DjangoDocutilsLibTextSettings(t.TypedDict):
     """Core settings object for ``DJANGO_DOCUTILS_LIB_TEXT``."""
 
     uncapitalized_word_filters: list[str]

--- a/uv.lock
+++ b/uv.lock
@@ -472,6 +472,7 @@ dev = [
     { name = "types-docutils" },
     { name = "types-pygments" },
     { name = "types-pytz" },
+    { name = "typing-extensions" },
 ]
 docs = [
     { name = "gp-libs" },
@@ -492,6 +493,7 @@ lint = [
     { name = "types-docutils" },
     { name = "types-pygments" },
     { name = "types-pytz" },
+    { name = "typing-extensions" },
 ]
 testing = [
     { name = "dj-inmemorystorage" },
@@ -543,6 +545,7 @@ dev = [
     { name = "types-docutils" },
     { name = "types-pygments" },
     { name = "types-pytz" },
+    { name = "typing-extensions" },
 ]
 docs = [
     { name = "gp-libs", specifier = ">=0.0.18" },
@@ -562,6 +565,7 @@ lint = [
     { name = "types-docutils" },
     { name = "types-pygments" },
     { name = "types-pytz" },
+    { name = "typing-extensions" },
 ]
 testing = [
     { name = "dj-inmemorystorage" },


### PR DESCRIPTION
## Summary

- **Fix**: `django_docutils.lib.publisher` and `django_docutils.lib.types` imported `typing_extensions` at module scope, but it was never declared in `[project].dependencies`. Installing django-docutils into an environment that did not already provide it raised `ModuleNotFoundError` on the template backend, the `{% rst %}` tag/filter, and `DocutilsView` — the package's main public entry points.
- **Add**: `scripts/runtime_dep_smoketest.py`, which installs the package with *only* its declared runtime dependencies, imports every module, and renders reStructuredText through the publisher.
- **Add**: a CI step running that smoke test on each matrix Python, so a runtime import declared only in a dependency group fails the build instead of reaching PyPI.
- **Motivation**: the bug survived because `typing-extensions` is a transitive dependency of mypy, django-stubs, and most Django dev stacks. It is always present in a dev virtualenv, so no existing test could observe its absence.

## Before / after

Against a clean install carrying only `django`, `docutils`, and `pygments`:

```console
$ python -c "import django_docutils.template"
ModuleNotFoundError: No module named 'typing_extensions'
```

```console
$ python -c "import django_docutils.template"
```

## Changes by area

### Fix

- **`src/django_docutils/lib/types.py`**, **`src/django_docutils/lib/publisher.py`**: source `TypedDict` from the standard library, and import `NotRequired` / `Unpack` under `t.TYPE_CHECKING`.
- **`pyproject.toml`**: declare `typing-extensions` explicitly in the `dev` and `lint` groups rather than relying on mypy to pull it in transitively.

### Detection

- **`scripts/runtime_dep_smoketest.py`**: bootstraps Django, walks and imports every module in the package, then renders RST through `publish_html_from_source` and `publish_toc_from_doctree`.
- **`scripts/test_runtime_dep_smoketest.py`**, **`conftest.py`**: a `uvx`-backed wrapper test, gated behind the `scripts__runtime_dep_smoketest` marker because it builds the project into a throwaway environment.
- **`.github/workflows/tests.yml`**: run the smoke test under `uvx --isolated`, pinned to the matrix Python.

## Design decisions

**Type-checking-only import, not a conditional runtime dependency.** The alternative was declaring `typing-extensions; python_version < "3.11"` as a real dependency. Keeping it out of published metadata entirely is cheaper for downstream users, and costs nothing: `from __future__ import annotations` means `NotRequired` and `Unpack` are never evaluated at runtime, and mypy still fully enforces the `Unpack[PublishHtmlDocTreeKwargs]` contract on both `**kwargs` names and value types.

**`TypedDict` must come from the stdlib, not `TYPE_CHECKING`.** It is a real base class evaluated at class-creation time, so unlike the other two it cannot be deferred. It has been in `typing` since 3.9, and the floor here is 3.10.

**The smoke test configures `DJANGO_DOCUTILS_LIB_RST`, and asserts on rendered output.** Roles and directives register *only* from that setting, and docutils degrades an unregistered role or directive into an error node rather than raising. A render check against an unconfigured project would therefore exercise neither pygments nor the role machinery, render a broken document, and still exit `0`. The check asserts on the fingerprint each dependency leaves in the HTML — pygments highlighting present, role URL resolved, no error nodes.

**The CI step is pinned to `--python ${{ matrix.python-version }}`.** `NotRequired` and `Unpack` are absent from the stdlib before 3.11, so a reintroduced runtime import would break on 3.10 and pass on 3.14. Running the probe on a single version would miss it.

## Verification

No module-scope import of `typing_extensions` remains (expect zero matches):

```console
$ rg -n '^from typing_extensions|^import typing_extensions' src/
```

`typing-extensions` appears only under `[dependency-groups]`, never in `[project].dependencies`:

```console
$ rg -n -A4 '^dependencies = ' pyproject.toml
```

The package imports and renders with only its runtime dependencies installed:

```console
$ uvx --isolated --no-cache --from . python scripts/runtime_dep_smoketest.py
```

## Test plan

- [x] `uv run ruff format . --check` — formatting clean
- [x] `uv run ruff check .` — lint clean
- [x] `uv run mypy .` — type-checks, including the `Unpack` kwargs contract
- [x] `uv run pytest` — full suite green, including the smoke test's doctests
- [x] `uv run pytest -m scripts__runtime_dep_smoketest` — smoke test passes in a clean `uvx` environment
- [x] `just build-docs` — docs build, changelog roles resolve
- [x] Smoke test confirmed to **fail** when the source fix is reverted, reporting all six affected modules — the detector is not vacuous
- [x] Smoke test confirmed to fail on a bare (unconfigured) Django bootstrap, proving the render assertions discriminate