### PR TITLE
docs(lib): Document TypedDict and NamedTuple fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,14 @@ $ uvx --from 'django-docutils' --prerelease allow django-docutils
 _Upcoming changes will be written here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Settings fields describe themselves in the API reference (#467)
+
+The `TypedDict` settings schemas and the writer's `NamedTuple` now say what
+each field holds. They previously reached the rendered API reference as
+"Alias for field number 0" or as a bare name carrying only its type.
+
 ### Development
 
 #### CI actions updated to current majors

--- a/src/django_docutils/lib/publisher.py
+++ b/src/django_docutils/lib/publisher.py
@@ -184,7 +184,16 @@ def publish_doctree(
 
 
 class PublishHtmlDocTreeKwargs(t.TypedDict):
-    """Keyword arguments accepted by publish_html_from_source."""
+    """Keyword arguments accepted by publish_html_from_source.
+
+    Attributes
+    ----------
+    show_title : NotRequired[bool]
+        Render the document title above the body. Omitted means ``True``.
+    toc_only : NotRequired[bool]
+        Return only the table of contents, for sidebars, rather than the
+        document body. Omitted means ``False``.
+    """
 
     show_title: NotRequired[bool]
     toc_only: NotRequired[bool]

--- a/src/django_docutils/lib/types.py
+++ b/src/django_docutils/lib/types.py
@@ -6,13 +6,44 @@ import typing as t
 
 
 class DjangoDocutilsLibRSTRolesSettings(t.TypedDict, total=False):
-    """Docutils role mappings."""
+    """Docutils role mappings.
+
+    Attributes
+    ----------
+    local : dict[str, str]
+        Role name to import string of the callable implementing it, registered
+        with docutils at startup and again whenever settings change.
+    """
 
     local: dict[str, str]
 
 
 class DjangoDocutilsLibRSTDocutilsSettings(t.TypedDict, total=False):
-    """Docutils document settings."""
+    """Docutils document settings.
+
+    Attributes
+    ----------
+    file_insertion_enabled : bool
+        Allow directives that read from the filesystem, such as ``include``.
+        Held at ``False`` unless the project sets
+        ``allow_unsafe_docutils_settings``.
+    raw_enabled : bool
+        Allow the ``raw`` directive and role to emit unescaped markup. Held at
+        ``False`` unless the project sets ``allow_unsafe_docutils_settings``.
+    _disable_config : bool
+        Ignore ``docutils.conf`` files found on disk. Held at ``True`` unless
+        the project sets ``allow_unsafe_docutils_settings``.
+    line_length_limit : int
+        Longest input line docutils will parse. Clamped back down to the
+        django-docutils default unless the project sets
+        ``allow_unsafe_docutils_settings``.
+    strip_comments : bool
+        Drop RST comments from the doctree instead of carrying them through to
+        the output.
+    initial_header_level : int
+        HTML heading level a top-level section title renders as, so nested
+        sections count up from there.
+    """
 
     file_insertion_enabled: bool
     raw_enabled: bool
@@ -23,7 +54,31 @@ class DjangoDocutilsLibRSTDocutilsSettings(t.TypedDict, total=False):
 
 
 class DjangoDocutilsLibRSTSettings(t.TypedDict, total=False):
-    """Core settings object for ``DJANGO_DOCUTILS_LIB_RST``."""
+    """Core settings object for ``DJANGO_DOCUTILS_LIB_RST``.
+
+    Attributes
+    ----------
+    allow_unsafe_docutils_settings : bool
+        Opt in to overriding the protected docutils defaults and to keeping
+        unsafe URI schemes in rendered output.
+    allowed_uri_schemes : t.Sequence[str]
+        URI schemes kept in rendered links and images. Unset means http,
+        https, and mailto; unsafe schemes are stripped unless
+        ``allow_unsafe_docutils_settings`` is set.
+    metadata_processors : list[str]
+        Import strings of callables applied in order to a document's extracted
+        metadata, each taking and returning the metadata mapping.
+    transforms : list[str]
+        Import strings of :class:`docutils.transforms.Transform` subclasses
+        appended to the writer's transforms.
+    docutils : DjangoDocutilsLibRSTDocutilsSettings
+        Docutils publisher settings layered over the django-docutils defaults.
+    directives : dict[str, str]
+        Directive name to import string of the
+        :class:`docutils.parsers.rst.Directive` subclass registered for it.
+    roles : DjangoDocutilsLibRSTRolesSettings
+        Role registrations, grouped by the scope they are registered in.
+    """
 
     allow_unsafe_docutils_settings: bool
     allowed_uri_schemes: t.Sequence[str]
@@ -35,6 +90,14 @@ class DjangoDocutilsLibRSTSettings(t.TypedDict, total=False):
 
 
 class DjangoDocutilsLibTextSettings(t.TypedDict):
-    """Core settings object for ``DJANGO_DOCUTILS_LIB_TEXT``."""
+    """Core settings object for ``DJANGO_DOCUTILS_LIB_TEXT``.
+
+    Attributes
+    ----------
+    uncapitalized_word_filters : list[str]
+        Import strings of predicates taking a single word. A filter returning
+        ``True`` keeps that word as-authored during title casing; an empty list
+        capitalizes every word.
+    """
 
     uncapitalized_word_filters: list[str]

--- a/src/django_docutils/lib/writers.py
+++ b/src/django_docutils/lib/writers.py
@@ -15,7 +15,19 @@ from .settings import DJANGO_DOCUTILS_LIB_RST
 
 
 class ParentNodeClassTuple(t.NamedTuple):
-    """Typing for parent node accepting custom arguments."""
+    """Typing for parent node accepting custom arguments.
+
+    Attributes
+    ----------
+    parent_node_type : type[docutils.nodes.Node | docutils.nodes.Body]
+        Parent node class the title must be wrapped in for this entry to apply.
+    args : list[str]
+        Positional arguments passed to ``starttag``.
+    kwargs : dict[str, str]
+        HTML attributes passed to ``starttag``.
+    close_tag : str | None
+        Closing tag emitted after the title, or ``None`` to keep the default.
+    """
 
     parent_node_type: type[nodes.Node | nodes.Body]
     args: list[str]


### PR DESCRIPTION
Adds NumPy-style `Attributes` sections to the `TypedDict` and `NamedTuple` types in `django_docutils.lib`. Without them the API reference renders `NamedTuple` fields as "Alias for field number 0" and `TypedDict` keys bare, so readers could not tell what a settings key controls, what a rendering flag does when omitted, or which docutils keys the security defaults hold at their safe value regardless of what a project configures. Docstrings only — no code, signature, or field-order changes.

Gates run and passing: `just ruff-format`, `just ruff`, `just test`, `just build-docs`. `uv run mypy .` reports two pre-existing `arg-type` errors in `lib/roles/registry.py`, identical on master and untouched by this branch.

The docs build now emits duplicate-object description warnings for every newly documented field: the NumPy preprocessor emits `.. attribute::` for each `Attributes` entry while autodoc also renders the same field, so Sphinx sees two descriptions of one object. These are cosmetic and cover only the fields documented here. Leaving them unsuppressed on purpose — the fix belongs in gp-sphinx and is landing there separately, rather than papering over it in `docs/conf.py`.

Closes #466
