### PR TITLE
Django 5.2 through 6.1: drop EOL series, fix the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.14']
-        django-version: ['4.2', '5.1', '5.2']
+        django-version: ['4.2', '5.1', '5.2', '6.0', '6.1']
+        exclude:
+          # django 6.x requires python 3.12+
+          - python-version: '3.10'
+            django-version: '6.0'
+          - python-version: '3.10'
+            django-version: '6.1'
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    # `uv run` syncs the environment from uv.lock first, which would
+    # reinstall the locked django over the one the matrix leg installed.
+    env:
+      UV_NO_SYNC: '1'
     strategy:
       matrix:
         python-version: ['3.10', '3.14']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     # `uv run` syncs the environment from uv.lock first, which would
     # reinstall the locked django over the one the matrix leg installed.
+    # `uv python install` only makes an interpreter available; `.python-version`
+    # still selects it, so UV_PYTHON is what binds a leg to its python.
     env:
       UV_NO_SYNC: '1'
+      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       matrix:
         python-version: ['3.10', '3.14']
@@ -38,19 +41,23 @@ jobs:
 
       - name: Print versions
         env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
           DJANGO_VERSION: ${{ matrix.django-version }}
         run: |
-          python -V
-          uv run python -V
           uv run python - <<'PY'
           import os
+          import sys
+
           import django
 
-          want = os.environ["DJANGO_VERSION"]
-          got = django.get_version()
-          print("Django", got)
-          if got.split(".")[:2] != want.split("."):
-              raise SystemExit(f"expected Django {want}.x, got {got}")
+          checks = (
+              ("Python", os.environ["PYTHON_VERSION"], "%d.%d" % sys.version_info[:2]),
+              ("Django", os.environ["DJANGO_VERSION"], django.get_version()),
+          )
+          for name, want, got in checks:
+              print(name, got)
+              if got.split(".")[:2] != want.split("."):
+                  raise SystemExit(f"expected {name} {want}.x, got {got}")
           PY
 
       - name: Lint with ruff check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Install django @ ${{ matrix.django-version }}
-        run: uv pip install DJANGO~=${{ matrix.django-version }}
+        run: uv pip install DJANGO~=${{ matrix.django-version }}.0
 
       - name: Print python versions
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.14']
-        django-version: ['4.2', '5.1', '5.2', '6.0', '6.1']
+        django-version: ['5.2', '6.0', '6.1']
         exclude:
           # django 6.x requires python 3.12+
           - python-version: '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,22 @@ jobs:
       - name: Install django @ ${{ matrix.django-version }}
         run: uv pip install DJANGO~=${{ matrix.django-version }}.0
 
-      - name: Print python versions
+      - name: Print versions
+        env:
+          DJANGO_VERSION: ${{ matrix.django-version }}
         run: |
           python -V
           uv run python -V
+          uv run python - <<'PY'
+          import os
+          import django
+
+          want = os.environ["DJANGO_VERSION"]
+          got = django.get_version()
+          print("Django", got)
+          if got.split(".")[:2] != want.split("."):
+              raise SystemExit(f"expected Django {want}.x, got {got}")
+          PY
 
       - name: Lint with ruff check
         run: uv run ruff check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Key features:
 
 This project uses:
 - Python 3.10+
-- Django 4.2 through 6.1 (6.x requires Python 3.12+)
+- Django 5.2 through 6.1 (6.x requires Python 3.12+)
 - [uv](https://github.com/astral-sh/uv) for dependency management
 - [ruff](https://github.com/astral-sh/ruff) for linting/formatting
 - [mypy](https://github.com/python/mypy) with `django-stubs` for typing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Key features:
 
 This project uses:
 - Python 3.10+
-- Django 4.2/5.1/5.2
+- Django 4.2 through 6.1 (6.x requires Python 3.12+)
 - [uv](https://github.com/astral-sh/uv) for dependency management
 - [ruff](https://github.com/astral-sh/ruff) for linting/formatting
 - [mypy](https://github.com/python/mypy) with `django-stubs` for typing

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,24 @@ $ uvx --from 'django-docutils' --prerelease allow django-docutils
 _Upcoming changes will be written here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Breaking changes
+
+#### Django 5.2 is the minimum supported Django (#469)
+
+Minimum `django>=5.2` (was `>=4.2`). Django 4.2 LTS reached end of extended
+support in April 2026 and Django 5.1 in December 2025, so neither receives
+security fixes. Both leave the trove classifiers and the test matrix.
+
+Projects on 4.2 or 5.1 should move to 5.2 LTS, which is supported through April
+2028:
+
+```console
+$ pip install --upgrade 'django>=5.2'
+```
+
+The Python floor is unchanged: Django 5.2 supports Python 3.10 through 3.14, so
+installations on 3.10 and 3.11 keep resolving 5.2 while 3.12+ can take 6.x.
+
 ### Dependencies
 
 Minimum `ruff>=0.16.0` (was unpinned) for linting and formatting (#468). Ruff

--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,15 @@ Minimum `ruff>=0.16.0` (was unpinned) for linting and formatting (#468). Ruff
 now formats Python code blocks inside Markdown, so `ruff format` reaches the
 README and the docs alongside the source tree.
 
+### What's new
+
+#### Django 6.1 support (#469)
+
+django-docutils runs on Django 6.1 and 6.0, both now declared in the package
+metadata and covered by CI. Django 6.x requires Python 3.12 or newer;
+installations on Python 3.10 and 3.11 continue to resolve Django 5.2. Upgrading
+requires no code changes.
+
 ### Documentation
 
 #### Settings fields describe themselves in the API reference (#467)
@@ -59,17 +68,10 @@ flake8-blind-except, and flake8-pytest-style among them.
 
 #### The test matrix runs the versions it names (#469)
 
-Legs pinned Django with `~=X.Y`, which floats across an entire major series, and
-`uv run` re-synced the environment from `uv.lock` before running the suite.
-Together those meant every leg tested whatever the lockfile resolved for its
-Python, regardless of the version the leg named. Legs now install `~=X.Y.0` and
-run with `UV_NO_SYNC`.
-
-The Python axis was inert for a separate reason: `uv python install` only makes
-an interpreter available, and `.python-version` still selected the one the
-project used, so every leg ran Python 3.14 -- including those named 3.10.
-`UV_PYTHON` now binds each leg to its own interpreter, and a leg fails outright
-when the Python or the Django it is running is not the one it asked for.
+Every CI job silently ran one Python and one Django — whichever the lockfile
+resolved — regardless of the pair it was named for. Both axes now install what
+the job names, and a job fails outright when they do not match, so the support
+claims above are tested rather than assumed.
 
 #### CI actions updated to current majors
 

--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,20 @@ set, so the config uses `extend-select` instead. Contributors will see findings
 from linters the project never listed — flake8-bandit, flake8-datetimez,
 flake8-blind-except, and flake8-pytest-style among them.
 
+#### The test matrix runs the versions it names (#469)
+
+Legs pinned Django with `~=X.Y`, which floats across an entire major series, and
+`uv run` re-synced the environment from `uv.lock` before running the suite.
+Together those meant every leg tested whatever the lockfile resolved for its
+Python, regardless of the version the leg named. Legs now install `~=X.Y.0` and
+run with `UV_NO_SYNC`.
+
+The Python axis was inert for a separate reason: `uv python install` only makes
+an interpreter available, and `.python-version` still selected the one the
+project used, so every leg ran Python 3.14 -- including those named 3.10.
+`UV_PYTHON` now binds each leg to its own interpreter, and a leg fails outright
+when the Python or the Django it is running is not the one it asked for.
+
 #### CI actions updated to current majors
 
 Workflow actions moved to their current major releases: `actions/checkout` v7,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ DJANGO_DOCUTILS_LIB_RST = {
 ## More information
 
 - Python 3.10+
-- Django 4.2+
+- Django 5.2+
 - [Documentation](https://django-docutils.git-pull.com/) ·
   [Quickstart](https://django-docutils.git-pull.com/quickstart.html) ·
   [Security](https://django-docutils.git-pull.com/topics/security.html) ·

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv.exclude-newer-package]
+# The lock is what CI resolves against, so the cooldown would keep it on a
+# known-vulnerable django for three days after each security release.
+django = false
+
 # git-pull packages release in lockstep with their workspaces, so a
 # fresh release blocking on the 3-day cooldown blocks every
 # contributor's `uv sync` until it clears. `false` exempts each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
   'Framework :: Django :: 4.2',
   'Framework :: Django :: 5.1',
   'Framework :: Django :: 5.2',
+  'Framework :: Django :: 6.0',
+  'Framework :: Django :: 6.1',
   'Intended Audience :: Developers',
   'License :: OSI Approved :: MIT License',
   'Natural Language :: English',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ readme = "README.md"
 classifiers = [
   'Development Status :: 2 - Pre-Alpha',
   'Framework :: Django',
-  'Framework :: Django :: 4.2',
-  'Framework :: Django :: 5.1',
   'Framework :: Django :: 5.2',
   'Framework :: Django :: 6.0',
   'Framework :: Django :: 6.1',
@@ -36,7 +34,7 @@ include = [
   { path = "tests", format = "sdist" },
 ]
 dependencies = [
-  "django>=4.2",
+  "django>=5.2",
   "docutils",
   "pygments<3"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -16,10 +16,11 @@ exclude-newer-span = "P3D"
 gp-sphinx = false
 sphinx-autodoc-sphinx = false
 sphinx-autodoc-api-style = false
+django = false
 sphinx-autodoc-fastmcp = false
 sphinx-autodoc-pytest-fixtures = false
-sphinx-gp-llms = false
 sphinx-autodoc-argparse = false
+sphinx-gp-llms = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
 gp-libs = false
@@ -380,7 +381,7 @@ version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/5b/89366ae96a0213437fd40b2e76791e8adcf790eda597a879bd2595bc41a5/dj-inmemorystorage-2.1.0.tar.gz", hash = "sha256:1771801613414262803a1a1e97dafd2b7a563e78fbcbfa2b6f841c9d8e7b872a", size = 6963, upload-time = "2020-03-30T17:49:12.045Z" }
@@ -408,7 +409,7 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.8"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -419,9 +420,9 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/28/5fee292e588dbdb782582436d1eb62ac8809ec55b98ef27f5b9676a00e9a/django-6.0.8.tar.gz", hash = "sha256:cb0bd962d27fc866f3c514b20aae6a7df56ec80b488f9899da46d675cd051526", size = 10924565, upload-time = "2026-08-04T15:03:39.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/b4/23e74d261eebfa9c8baed5e8810f09858b9afd613d1037f42ff7aa95c87f/django-6.0.8-py3-none-any.whl", hash = "sha256:9b98b7e1902e0e575ea4f42c175fc9512784f7f2580898286aee3388b322219d", size = 8376956, upload-time = "2026-08-04T15:03:35.138Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -430,7 +431,7 @@ version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "docutils" },
     { name = "pygments" },
 ]
@@ -583,7 +584,7 @@ version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "django-stubs-ext" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-pyyaml" },
@@ -600,7 +601,7 @@ version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/50/917f7224ea470e89cdcdc93d3dfe75b8391adf976cf12f2ecdb5f5d122be/django_stubs_ext-6.0.7.tar.gz", hash = "sha256:c3172c5126614fd2a44d0196b313b44c21f717cb09477ba52b447d41f4ce613e", size = 6665, upload-time = "2026-07-14T10:07:56.933Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "docutils" },
     { name = "pygments", specifier = "<3" },
     { name = "pytz", marker = "extra == 'pytz'" },


### PR DESCRIPTION
## Summary

- **Break** installs pinned below Django 5.2: the floor moves from `django>=4.2` to `django>=5.2`. Django 4.2 LTS reached end of extended support on 2026-04-07 and 5.1 on 2025-12-03, so neither receives security fixes. Both leave the classifiers and the matrix.
- **Add** Django 6.1 support alongside 6.0, both declared in the trove classifiers, with `uv.lock` resolving 6.1 on Python 3.12+. No source changes were needed — the 6.1 removals and the `django.template.library.parse_bits()` signature change don't reach this package's imports.
- **Fix** matrix legs installing `django~=X.Y`, a specifier that floats across an entire major series. The `5.1` leg resolved 5.2.17, duplicating the `5.2` leg.
- **Fix** `uv run` re-syncing the environment from `uv.lock` before every step, which uninstalled the Django the leg had just installed.
- **Fix** the Python axis, inert for a third reason: `uv python install` only makes an interpreter available, and `.python-version` still selected the one the project uses, so every leg ran Python 3.14 — including those named 3.10. Python 3.10 support was declared but never exercised.
- **Guard** both axes against a further silent regression: a leg now fails when the Python or the Django it is running is not the one it named.
- **Exempt** `django` from the 3-day `uv` release cooldown so security releases reach the lockfile, and therefore CI, the day they ship.

## What each leg actually installs

| Leg | Actually ran before | Runs now |
|---|---|---|
| py3.10 × 5.2 | py3.14 + django 6.0.8 | py3.10 + django 5.2.x |
| py3.14 × 5.2 | py3.14 + django 6.0.8 | py3.14 + django 5.2.x |
| py3.14 × 6.0 | — | py3.14 + django 6.0.x |
| py3.14 × 6.1 | — | py3.14 + django 6.1 |

Every leg on `master` ran the same pair. The matrix had six names and one job. The 4.2 and 5.1 legs are gone with the floor bump.

## Design decisions

- **`~=X.Y.0` rather than `==X.Y.*`** — `~=5.2.0` means `>=5.2.0, ==5.2.*`, so a leg tracks its series' latest security patch without crossing into the next feature release.
- **`UV_NO_SYNC` on the job rather than `--no-sync` per step** — one declaration covers every `uv run` in the job and can't be forgotten when a step is added later. The explicit `uv sync --all-extras --dev` step is unaffected.
- **`UV_PYTHON` rather than rewriting `.python-version`** — the checked-in `.python-version` is what contributors get locally and should stay pinned; the env var overrides it per leg without the workflow editing a tracked file mid-run.
- **The guard compares two version segments** — `django.get_version()` returns `6.1` for a `.0` release, not `6.1.0`, so a `startswith('6.1.')` check would fail the very leg it exists to protect. Both matrix values reach the script through `env` rather than string interpolation.
- **`django = false` rather than a dated exemption** — a date sets Django's own `exclude-newer` bound, which would block future security releases until someone edits the value: the opposite of the intent.
- **The Python floor stays at 3.10** — Django 5.2 supports Python 3.10 through 3.14, so dropping the older Django series costs no Python coverage. Installations on 3.10 and 3.11 resolve 5.2; 3.12+ can take 6.x.

## Verification

`~=X.Y` floats across the major series:

```
uv pip install --dry-run 'django~=5.1'
```

Resolves `django==5.2.17`. With the trailing `.0`:

```
uv pip install --dry-run 'django~=5.1.0'
```

Resolves `django==5.1.15`. And `uv run` reverts a leg's install unless `UV_NO_SYNC` is set:

```
uv pip install 'django~=5.2.0' && uv run python -c "import django; print(django.get_version())"
```

Prints the locked version rather than 5.2.17; re-run with `UV_NO_SYNC=1` and it prints 5.2.17.

The Python axis fails the same way. In a project whose `.python-version` reads `3.14`:

```
uv python install 3.10 && uv run python -V
```

Prints `3.14`, not `3.10` — installing an interpreter does not select it. With `UV_PYTHON=3.10` set, the same command prints `3.10`.

## Test plan

- [x] Full suite passes on Python 3.14 against each supported Django: 5.2.17, 6.0.8, 6.1
- [x] `uv run mypy .` clean against each of those Django versions
- [x] `uv run ruff check .` and `uv run ruff format . --check` clean
- [x] `just build-docs` — Sphinx build succeeds
- [x] Matrix expands to four jobs; both 6.x legs excluded on Python 3.10
- [x] Guard exits non-zero when the running Python or Django does not match the leg, and zero when both match
- [x] `uv.lock` still resolves 5.2.17 below Python 3.12 and 6.1 at or above it
- [x] CI green across all four legs, each one's guard confirming it ran the pair it names
