### PR TITLE
Publish the project links to PyPI

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,13 @@ $ uvx --from 'django-docutils' --prerelease allow django-docutils
 _Upcoming changes will be written here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+#### Project links on PyPI (#470)
+
+The PyPI page now shows the documentation, repository, issue tracker, changelog,
+and discussions links, which no previous release shipped.
+
 ### Development
 
 #### The source distribution carries only the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,14 @@ classifiers = [
   "Typing :: Typed",
 ]
 keywords = ["django", "docutils", "reStructuredText", "rst", "reST"]
-homepage = "https://django-docutils.git-pull.com"
 dependencies = [
   "django>=5.2",
   "docutils",
   "pygments<3"
 ]
 
-[tool.project]
+[project.urls]
+Homepage = "https://django-docutils.git-pull.com"
 "Bug Tracker" = "https://github.com/tony/django-docutils/issues"
 Documentation = "https://django-docutils.git-pull.com"
 Repository = "https://github.com/tony/django-docutils"


### PR DESCRIPTION
## Summary

- **Fix** the package's URL table, declared as `[tool.project]` instead of `[project.urls]`. `[tool.*]` is the namespace PEP 621 reserves for tool-specific config, so hatchling ignored the block entirely and no release has ever carried `Project-URL` metadata. The empty PyPI sidebar was the symptom, not the cause.
- **Fold** the `homepage` key into the table as `Homepage`. It sat directly under `[project]`, which has no such field — another key that produced no metadata.

Both are leftovers from the Poetry-to-hatchling migration: valid Poetry config, inert under a PEP 621 backend.

## Before / after

`Project-URL` lines in the built wheel's `METADATA`, before:

```
```

After:

```
Project-URL: Homepage, https://django-docutils.git-pull.com
Project-URL: Bug Tracker, https://github.com/tony/django-docutils/issues
Project-URL: Documentation, https://django-docutils.git-pull.com
Project-URL: Repository, https://github.com/tony/django-docutils
Project-URL: Changes, https://github.com/tony/django-docutils/blob/master/CHANGES
Project-URL: Q & A, https://github.com/tony/django-docutils/discussions
```

## Verification

The published package carries no project-url metadata at all — this is not a PyPI rendering issue:

```
curl -s https://pypi.org/pypi/django-docutils/json | jq -r '.info.project_urls'
```

Returns `null`. The same query against a sibling package that declares `[project.urls]` correctly returns its four links:

```
curl -s https://pypi.org/pypi/django-slugify-processor/json | jq -r '.info.project_urls | keys'
```

## Test plan

- [x] Built wheel `METADATA` carries six `Project-URL` lines; it carried zero before
- [x] `uv run pytest` — suite passes
- [x] `uv run ruff check .` and `uv run ruff format . --check` clean
- [x] `uv run mypy .` clean
- [x] `just build-docs` — Sphinx build succeeds
- [ ] Links visible on the PyPI page — only observable after the next release, since metadata is fixed per release